### PR TITLE
fix: replace native confirm() with in-app DeleteAccountModal

### DIFF
--- a/frontend/src/components/AccountList.tsx
+++ b/frontend/src/components/AccountList.tsx
@@ -100,6 +100,7 @@ export function AccountList() {
   const [selectedGame, setSelectedGame] = useState<string | null>(null)
   const [showLinkModal, setShowLinkModal] = useState(false)
   const [showSettingsModal, setShowSettingsModal] = useState(false)
+  const [deletingAccount, setDeletingAccount] = useState<models.Account | null>(null)
 
   // Filter by game then sort accounts
   const accounts = useMemo(() => {
@@ -169,10 +170,10 @@ export function AccountList() {
     setTimeout(() => setCopiedId(null), 2000)
   }
 
-  const handleDelete = async (id: string) => {
-    if (confirm('Are you sure you want to delete this account?')) {
-      await removeAccount(id)
-    }
+  const confirmDelete = async () => {
+    if (!deletingAccount) return
+    await removeAccount(deletingAccount.id)
+    setDeletingAccount(null)
   }
 
   const getRankForGame = (account: models.Account, gameId: string) => {
@@ -480,7 +481,7 @@ export function AccountList() {
                           <Pencil className="w-4 h-4" />
                         </button>
                         <button
-                          onClick={() => handleDelete(account.id)}
+                          onClick={() => setDeletingAccount(account)}
                           className="p-2 rounded-lg text-[var(--color-muted-foreground)] hover:text-red-400 hover:bg-red-500/10 transition-colors duration-150"
                         >
                           <Trash2 className="w-4 h-4" />
@@ -617,6 +618,15 @@ export function AccountList() {
             setShowAddModal(false)
             setEditingAccount(null)
           }}
+        />
+      )}
+
+      {/* Delete Confirmation Modal */}
+      {deletingAccount && (
+        <DeleteAccountModal
+          account={deletingAccount}
+          onCancel={() => setDeletingAccount(null)}
+          onConfirm={confirmDelete}
         />
       )}
 
@@ -1187,6 +1197,75 @@ export function AccountModal({ account, onClose }: { account: models.Account | n
               {loading ? 'Saving...' : (account ? 'Save' : 'Add')}
             </button>
           </div>
+      </div>
+    </div>
+  )
+}
+
+// Delete confirmation modal — in-app replacement for window.confirm()
+export function DeleteAccountModal({
+  account,
+  onCancel,
+  onConfirm,
+}: {
+  account: models.Account
+  onCancel: () => void
+  onConfirm: () => void | Promise<void>
+}) {
+  const [loading, setLoading] = useState(false)
+
+  const handleConfirm = async () => {
+    setLoading(true)
+    try {
+      await onConfirm()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const label = account.displayName || account.username
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50">
+      <div className="w-full max-w-[95%] sm:max-w-sm bg-[var(--color-card)] rounded-xl sm:rounded-2xl border border-[var(--color-border)] overflow-hidden shadow-2xl flex flex-col">
+        <div className="p-3 sm:p-4 border-b border-[var(--color-border)] shrink-0 flex items-center gap-2 sm:gap-3">
+          <div className="w-8 h-8 sm:w-9 sm:h-9 rounded-full bg-red-500/10 flex items-center justify-center shrink-0">
+            <Trash2 className="w-4 h-4 sm:w-4.5 sm:h-4.5 text-red-400" />
+          </div>
+          <h2 className="text-base sm:text-lg font-bold text-[var(--color-foreground)]">
+            Delete account?
+          </h2>
+        </div>
+
+        <div className="p-3 sm:p-4 text-sm text-[var(--color-muted-foreground)] space-y-2">
+          <p>
+            This will permanently delete{' '}
+            <span className="text-[var(--color-foreground)] font-medium">{label}</span>{' '}
+            from your vault. This cannot be undone.
+          </p>
+        </div>
+
+        <div className="p-3 sm:p-4 border-t border-[var(--color-border)] shrink-0 flex gap-2 sm:gap-3">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={loading}
+            className="flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm bg-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={loading}
+            className={cn(
+              'flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm transition-colors text-white',
+              'bg-red-500 hover:bg-red-500/90 disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            {loading ? 'Deleting...' : 'Delete'}
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/components/__tests__/DeleteAccountModal.test.tsx
+++ b/frontend/src/components/__tests__/DeleteAccountModal.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DeleteAccountModal } from '../AccountList'
+import { models } from '../../../wailsjs/go/models'
+
+function buildAccount(overrides: Partial<models.Account> = {}): models.Account {
+  return {
+    id: 'acct-1',
+    displayName: 'Main Smurf',
+    username: 'smurf123',
+    password: 'hunter2',
+    networkId: 'riot',
+    tags: [],
+    notes: '',
+    riotId: '',
+    region: 'na1',
+    games: ['lol'],
+    cachedRanks: [],
+    puuid: '',
+    ...overrides,
+  } as models.Account
+}
+
+describe('DeleteAccountModal', () => {
+  it('calls onConfirm when user clicks Delete', async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <DeleteAccountModal
+        account={buildAccount()}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }))
+
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it('calls onCancel when user clicks Cancel', async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+
+    render(
+      <DeleteAccountModal
+        account={buildAccount()}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onConfirm).not.toHaveBeenCalled()
+  })
+
+  it('shows the account label in the confirmation copy', () => {
+    render(
+      <DeleteAccountModal
+        account={buildAccount({ displayName: 'Main Smurf' })}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Main Smurf')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
## Summary
- Account delete flow used `window.confirm()` — renders the raw WebView "wails.localhost says" dialog with default styling (see screenshot from user report). Jarring and off-brand.
- Replace with an in-app `DeleteAccountModal` that matches `AccountModal` styling (CSS var theme, bordered header/footer, red trash icon). Shows the account's display name so there's no ambiguity about what's being deleted.
- Swept the rest of the frontend for `confirm/alert/prompt` calls — this was the only one.

## Changes
- `frontend/src/components/AccountList.tsx`:
  - New `DeleteAccountModal` component.
  - `AccountList` tracks `deletingAccount` state; delete icon sets it; modal calls `removeAccount` on confirm.
- `frontend/src/components/__tests__/DeleteAccountModal.test.tsx` — three tests: onConfirm fires, onCancel fires, account label is shown.
- `frontend/src/test/setup.ts` — add `afterEach(cleanup)` so sibling render tests don't leak DOM into each other.

## Test plan
- [ ] CI: frontend build + vitest pass
- [ ] Manual smoke: unlock vault → click trash icon on an account → confirm modal matches app style → click **Delete** → account removed
- [ ] Manual smoke: click trash → **Cancel** → account not removed, modal closes
- [ ] Manual smoke: confirm modal shows the account's display name (or username fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)