### PR TITLE
feat: progressive-disclosure Add Account wizard

### DIFF
--- a/frontend/src/components/AccountList.tsx
+++ b/frontend/src/components/AccountList.tsx
@@ -19,6 +19,7 @@ import { cn } from '../lib/utils'
 import { models, providers } from '../../wailsjs/go/models'
 import { RecoveryPhraseModal } from './RecoveryPhraseModal'
 import { SettingsModal } from './SettingsModal'
+import { AddAccountWizard } from './AddAccountWizard'
 
 // Rank tier ordering for sorting (higher = better)
 const TIER_ORDER: Record<string, number> = {
@@ -610,14 +611,16 @@ export function AccountList() {
         </div>
       </div>
 
-      {/* Add/Edit Modal */}
-      {(showAddModal || editingAccount) && (
+      {/* Add flow — progressive-disclosure wizard */}
+      {showAddModal && (
+        <AddAccountWizard onClose={() => setShowAddModal(false)} />
+      )}
+
+      {/* Edit flow — one-page form (user already knows the fields) */}
+      {editingAccount && (
         <AccountModal
           account={editingAccount}
-          onClose={() => {
-            setShowAddModal(false)
-            setEditingAccount(null)
-          }}
+          onClose={() => setEditingAccount(null)}
         />
       )}
 

--- a/frontend/src/components/AddAccountWizard.tsx
+++ b/frontend/src/components/AddAccountWizard.tsx
@@ -1,0 +1,488 @@
+import { useMemo, useState } from 'react'
+import {
+  Search,
+  ChevronLeft,
+  Check,
+  Gamepad2,
+  Swords,
+  Crosshair,
+  Sparkles,
+  Flame,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+import { useAppStore } from '../stores/appStore'
+import { cn } from '../lib/utils'
+import { models } from '../../wailsjs/go/models'
+
+// Progressive-disclosure add-account wizard.
+// Step 1: Identity (username, password, optional display name)
+// Step 2: Network picker (visual tiles + fuzzy search)
+// Step 3: Network-specific details (all optional — sensible defaults let users
+//         skip straight to Save)
+
+type Step = 'identity' | 'network' | 'details'
+
+const STEPS: Step[] = ['identity', 'network', 'details']
+
+const NETWORK_VISUAL: Record<string, { icon: LucideIcon; color: string }> = {
+  riot: { icon: Flame, color: 'text-red-400 bg-red-500/10 border-red-500/30' },
+}
+
+const GAME_VISUAL: Record<string, { icon: LucideIcon; color: string }> = {
+  lol: { icon: Swords, color: 'text-blue-300 bg-blue-500/10 border-blue-500/30' },
+  tft: { icon: Sparkles, color: 'text-purple-300 bg-purple-500/10 border-purple-500/30' },
+  valorant: { icon: Crosshair, color: 'text-rose-300 bg-rose-500/10 border-rose-500/30' },
+}
+
+const DEFAULT_VISUAL = { icon: Gamepad2, color: 'text-[var(--color-muted-foreground)] bg-[var(--color-muted)] border-[var(--color-border)]' }
+
+// Subsequence fuzzy match — lenient enough for typos ("leag" → "League of Legends")
+// without pulling in a full fuzzy-search dep for <20 items.
+export function fuzzyMatch(query: string, target: string): boolean {
+  const q = query.toLowerCase().trim()
+  if (!q) return true
+  const t = target.toLowerCase()
+  let qi = 0
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] === q[qi]) qi++
+  }
+  return qi === q.length
+}
+
+type WizardData = {
+  displayName: string
+  username: string
+  password: string
+  networkId: string
+  tags: string[]
+  notes: string
+  riotId: string
+  region: string
+  games: string[]
+}
+
+const EMPTY: WizardData = {
+  displayName: '',
+  username: '',
+  password: '',
+  networkId: '',
+  tags: [],
+  notes: '',
+  riotId: '',
+  region: 'na1',
+  games: [],
+}
+
+export function AddAccountWizard({ onClose }: { onClose: () => void }) {
+  const { gameNetworks, addAccount } = useAppStore()
+  const [step, setStep] = useState<Step>('identity')
+  const [data, setData] = useState<WizardData>(EMPTY)
+  const [submitting, setSubmitting] = useState(false)
+
+  const stepIndex = STEPS.indexOf(step)
+  const canAdvance =
+    (step === 'identity' && data.username.length > 0 && data.password.length > 0) ||
+    (step === 'network' && data.networkId.length > 0) ||
+    step === 'details'
+
+  const goBack = () => {
+    if (stepIndex > 0) setStep(STEPS[stepIndex - 1])
+    else onClose()
+  }
+
+  const goNext = () => {
+    if (!canAdvance) return
+    if (step === 'details') {
+      submit()
+      return
+    }
+    setStep(STEPS[stepIndex + 1])
+  }
+
+  const submit = async () => {
+    setSubmitting(true)
+    try {
+      const selectedNetwork = gameNetworks.find((n) => n.id === data.networkId)
+      // Default games to all games in the selected network if none picked
+      const games =
+        data.games.length > 0
+          ? data.games
+          : selectedNetwork?.games.map((g) => g.id) || []
+      await addAccount({
+        displayName: data.displayName || data.username,
+        username: data.username,
+        password: data.password,
+        networkId: data.networkId,
+        tags: data.tags,
+        notes: data.notes,
+        riotId: data.riotId,
+        region: data.region,
+        games,
+        cachedRanks: [],
+      })
+      onClose()
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const update = <K extends keyof WizardData>(key: K, value: WizardData[K]) =>
+    setData((prev) => ({ ...prev, [key]: value }))
+
+  return (
+    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50">
+      <div className="w-full max-w-[95%] sm:max-w-md bg-[var(--color-card)] rounded-xl sm:rounded-2xl border border-[var(--color-border)] overflow-hidden shadow-2xl max-h-[90vh] flex flex-col">
+        <WizardHeader step={step} />
+
+        <div className="p-3 sm:p-4 overflow-y-auto flex-1 space-y-3 sm:space-y-4">
+          {step === 'identity' && <IdentityStep data={data} update={update} />}
+          {step === 'network' && (
+            <NetworkStep data={data} update={update} networks={gameNetworks} />
+          )}
+          {step === 'details' && (
+            <DetailsStep data={data} update={update} networks={gameNetworks} />
+          )}
+        </div>
+
+        <div className="p-3 sm:p-4 border-t border-[var(--color-border)] shrink-0 flex gap-2 sm:gap-3">
+          <button
+            type="button"
+            onClick={goBack}
+            disabled={submitting}
+            className="flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm bg-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors disabled:opacity-50 flex items-center justify-center gap-1.5"
+          >
+            {stepIndex > 0 && <ChevronLeft className="w-4 h-4" />}
+            {stepIndex === 0 ? 'Cancel' : 'Back'}
+          </button>
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={!canAdvance || submitting}
+            className={cn(
+              'flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm transition-colors text-white',
+              'bg-[var(--color-primary)] hover:bg-[var(--color-primary)]/90',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            {step === 'details' ? (submitting ? 'Adding...' : 'Add Account') : 'Next'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function WizardHeader({ step }: { step: Step }) {
+  const titles: Record<Step, { title: string; subtitle: string }> = {
+    identity: { title: 'Add Account', subtitle: 'Start with your sign-in credentials' },
+    network: { title: 'Choose Network', subtitle: 'Which platform is this account for?' },
+    details: { title: 'Finishing Touches', subtitle: 'All optional — skip to save' },
+  }
+  const { title, subtitle } = titles[step]
+  const stepIndex = STEPS.indexOf(step)
+
+  return (
+    <div className="p-3 sm:p-4 border-b border-[var(--color-border)] shrink-0">
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <div className="min-w-0">
+          <h2 className="text-base sm:text-lg font-bold text-[var(--color-foreground)] truncate">
+            {title}
+          </h2>
+          <p className="text-xs text-[var(--color-muted-foreground)] truncate">{subtitle}</p>
+        </div>
+        <span className="text-[10px] sm:text-xs font-medium text-[var(--color-muted-foreground)] shrink-0">
+          Step {stepIndex + 1} of {STEPS.length}
+        </span>
+      </div>
+      <div className="flex gap-1.5">
+        {STEPS.map((s, i) => (
+          <div
+            key={s}
+            className={cn(
+              'h-1 flex-1 rounded-full transition-colors',
+              i <= stepIndex ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-muted)]',
+            )}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function IdentityStep({
+  data,
+  update,
+}: {
+  data: WizardData
+  update: <K extends keyof WizardData>(key: K, value: WizardData[K]) => void
+}) {
+  const inputClass = cn(
+    'w-full px-2.5 sm:px-3 py-2 rounded-lg sm:rounded-xl text-sm',
+    'bg-[var(--color-muted)] border border-[var(--color-border)]',
+    'text-[var(--color-foreground)] placeholder:text-[var(--color-muted-foreground)]',
+    'focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]',
+  )
+  return (
+    <>
+      <Field label="Username" required>
+        <input
+          type="text"
+          value={data.username}
+          onChange={(e) => update('username', e.target.value)}
+          placeholder="Enter username"
+          autoFocus
+          className={inputClass}
+        />
+      </Field>
+      <Field label="Password" required>
+        <input
+          type="text"
+          value={data.password}
+          onChange={(e) => update('password', e.target.value)}
+          placeholder="Enter password"
+          className={inputClass}
+        />
+      </Field>
+      <Field label="Display Name">
+        <input
+          type="text"
+          value={data.displayName}
+          onChange={(e) => update('displayName', e.target.value)}
+          placeholder="Optional — defaults to username"
+          className={inputClass}
+        />
+      </Field>
+    </>
+  )
+}
+
+function NetworkStep({
+  data,
+  update,
+  networks,
+}: {
+  data: WizardData
+  update: <K extends keyof WizardData>(key: K, value: WizardData[K]) => void
+  networks: models.GameNetwork[]
+}) {
+  const [query, setQuery] = useState('')
+  const filtered = useMemo(
+    () => networks.filter((n) => fuzzyMatch(query, n.name) || fuzzyMatch(query, n.id)),
+    [networks, query],
+  )
+
+  return (
+    <>
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--color-muted-foreground)]" />
+        <input
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search networks"
+          aria-label="Search networks"
+          className={cn(
+            'w-full pl-9 pr-3 py-2 rounded-lg sm:rounded-xl text-sm',
+            'bg-[var(--color-muted)] border border-[var(--color-border)]',
+            'text-[var(--color-foreground)] placeholder:text-[var(--color-muted-foreground)]',
+            'focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]',
+          )}
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <p className="text-sm text-[var(--color-muted-foreground)] text-center py-8">
+          No networks match "{query}".
+        </p>
+      ) : (
+        <div className="grid grid-cols-2 gap-2 sm:gap-3">
+          {filtered.map((n) => (
+            <Tile
+              key={n.id}
+              selected={data.networkId === n.id}
+              onClick={() => update('networkId', n.id)}
+              visual={NETWORK_VISUAL[n.id] || DEFAULT_VISUAL}
+              title={n.name}
+              subtitle={`${n.games.length} game${n.games.length === 1 ? '' : 's'}`}
+            />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+function DetailsStep({
+  data,
+  update,
+  networks,
+}: {
+  data: WizardData
+  update: <K extends keyof WizardData>(key: K, value: WizardData[K]) => void
+  networks: models.GameNetwork[]
+}) {
+  const network = networks.find((n) => n.id === data.networkId)
+  const [gameQuery, setGameQuery] = useState('')
+  const filteredGames = useMemo(
+    () => (network?.games || []).filter((g) => fuzzyMatch(gameQuery, g.name) || fuzzyMatch(gameQuery, g.id)),
+    [network, gameQuery],
+  )
+
+  const inputClass = cn(
+    'w-full px-2.5 sm:px-3 py-2 rounded-lg sm:rounded-xl text-sm',
+    'bg-[var(--color-muted)] border border-[var(--color-border)]',
+    'text-[var(--color-foreground)] placeholder:text-[var(--color-muted-foreground)]',
+    'focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]',
+  )
+
+  const toggleGame = (gameId: string) => {
+    const has = data.games.includes(gameId)
+    update('games', has ? data.games.filter((g) => g !== gameId) : [...data.games, gameId])
+  }
+
+  return (
+    <>
+      {network && network.games.length > 0 && (
+        <Field label="Games">
+          <div className="relative mb-2">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--color-muted-foreground)]" />
+            <input
+              type="text"
+              value={gameQuery}
+              onChange={(e) => setGameQuery(e.target.value)}
+              placeholder="Search games"
+              aria-label="Search games"
+              className={cn(inputClass, 'pl-9')}
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-2 sm:gap-3">
+            {filteredGames.map((g) => (
+              <Tile
+                key={g.id}
+                selected={data.games.includes(g.id)}
+                onClick={() => toggleGame(g.id)}
+                visual={GAME_VISUAL[g.id] || DEFAULT_VISUAL}
+                title={g.name}
+                subtitle={data.games.includes(g.id) ? 'Selected' : 'Tap to add'}
+              />
+            ))}
+          </div>
+          <p className="text-[11px] text-[var(--color-muted-foreground)] mt-1.5">
+            Leave empty to include all games on this network.
+          </p>
+        </Field>
+      )}
+
+      {data.networkId === 'riot' && (
+        <>
+          <Field label="Riot ID">
+            <input
+              type="text"
+              value={data.riotId}
+              onChange={(e) => update('riotId', e.target.value)}
+              placeholder="GameName#TAG"
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Region">
+            <select
+              value={data.region}
+              onChange={(e) => update('region', e.target.value)}
+              className={inputClass}
+            >
+              <option value="na1">NA</option>
+              <option value="euw1">EUW</option>
+              <option value="eun1">EUNE</option>
+              <option value="kr">KR</option>
+              <option value="br1">BR</option>
+              <option value="jp1">JP</option>
+              <option value="oc1">OCE</option>
+              <option value="la1">LAN</option>
+              <option value="la2">LAS</option>
+              <option value="tr1">TR</option>
+              <option value="ru">RU</option>
+            </select>
+          </Field>
+        </>
+      )}
+
+      <Field label="Notes">
+        <textarea
+          value={data.notes}
+          onChange={(e) => update('notes', e.target.value)}
+          placeholder="Optional"
+          rows={2}
+          className={cn(inputClass, 'resize-none')}
+        />
+      </Field>
+    </>
+  )
+}
+
+function Field({
+  label,
+  required,
+  children,
+}: {
+  label: string
+  required?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    <div className="space-y-1.5 sm:space-y-2">
+      <label className="text-xs sm:text-sm font-medium text-[var(--color-foreground)] flex items-center gap-1">
+        {label}
+        {required && <span className="text-red-400">*</span>}
+      </label>
+      {children}
+    </div>
+  )
+}
+
+function Tile({
+  selected,
+  onClick,
+  visual,
+  title,
+  subtitle,
+}: {
+  selected: boolean
+  onClick: () => void
+  visual: { icon: LucideIcon; color: string }
+  title: string
+  subtitle: string
+}) {
+  const Icon = visual.icon
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'group relative flex flex-col items-center gap-2 p-3 sm:p-4 rounded-xl border-2 transition-all',
+        'hover:scale-[1.02] active:scale-[0.98]',
+        selected
+          ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/5'
+          : 'border-[var(--color-border)] bg-[var(--color-muted)]/30 hover:border-[var(--color-muted-foreground)]/40',
+      )}
+      aria-pressed={selected}
+    >
+      {selected && (
+        <span className="absolute top-1.5 right-1.5 w-5 h-5 rounded-full bg-[var(--color-primary)] flex items-center justify-center">
+          <Check className="w-3 h-3 text-white" />
+        </span>
+      )}
+      <div
+        className={cn(
+          'w-10 h-10 sm:w-12 sm:h-12 rounded-lg flex items-center justify-center border',
+          visual.color,
+        )}
+      >
+        <Icon className="w-5 h-5 sm:w-6 sm:h-6" />
+      </div>
+      <div className="text-center">
+        <div className="text-sm font-medium text-[var(--color-foreground)]">{title}</div>
+        <div className="text-[10px] sm:text-xs text-[var(--color-muted-foreground)]">{subtitle}</div>
+      </div>
+    </button>
+  )
+}

--- a/frontend/src/components/__tests__/AddAccountWizard.test.tsx
+++ b/frontend/src/components/__tests__/AddAccountWizard.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const addAccount = vi.fn()
+
+vi.mock('../../stores/appStore', () => ({
+  useAppStore: () => ({
+    gameNetworks: [
+      {
+        id: 'riot',
+        name: 'Riot Games',
+        games: [
+          { id: 'lol', name: 'League of Legends', networkId: 'riot' },
+          { id: 'tft', name: 'Teamfight Tactics', networkId: 'riot' },
+          { id: 'valorant', name: 'Valorant', networkId: 'riot' },
+        ],
+      },
+      {
+        id: 'steam',
+        name: 'Steam',
+        games: [{ id: 'cs2', name: 'Counter-Strike 2', networkId: 'steam' }],
+      },
+    ],
+    addAccount,
+  }),
+}))
+
+import { AddAccountWizard, fuzzyMatch } from '../AddAccountWizard'
+
+describe('fuzzyMatch', () => {
+  it('matches subsequence regardless of gaps', () => {
+    expect(fuzzyMatch('lol', 'League of Legends')).toBe(true)
+    expect(fuzzyMatch('riot', 'Riot Games')).toBe(true)
+    expect(fuzzyMatch('tft', 'Teamfight Tactics')).toBe(true)
+  })
+
+  it('rejects when characters are out of order', () => {
+    expect(fuzzyMatch('xyz', 'League of Legends')).toBe(false)
+  })
+
+  it('treats empty query as match', () => {
+    expect(fuzzyMatch('', 'anything')).toBe(true)
+    expect(fuzzyMatch('  ', 'anything')).toBe(true)
+  })
+})
+
+describe('AddAccountWizard', () => {
+  beforeEach(() => {
+    addAccount.mockReset()
+  })
+
+  it('requires username and password before advancing from step 1', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    const next = screen.getByRole('button', { name: /next/i })
+    expect(next).toBeDisabled()
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    expect(next).toBeDisabled()
+
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    expect(next).toBeEnabled()
+  })
+
+  it('requires network selection before advancing from step 2', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Step 2 — network step. Next should be disabled until a tile is picked.
+    const nextOnStep2 = screen.getByRole('button', { name: /next/i })
+    expect(nextOnStep2).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: /riot games/i }))
+    expect(nextOnStep2).toBeEnabled()
+  })
+
+  it('filters network tiles with fuzzy search', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Both networks visible initially
+    expect(screen.getByRole('button', { name: /riot games/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /steam/i })).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText(/search networks/i), 'ste')
+
+    expect(screen.queryByRole('button', { name: /riot games/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /steam/i })).toBeInTheDocument()
+  })
+
+  it('submits with sensible defaults when user skips step 3', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<AddAccountWizard onClose={onClose} />)
+
+    // Step 1
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw123')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Step 2
+    await user.click(screen.getByRole('button', { name: /riot games/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Step 3 — skip straight to Add Account
+    await user.click(screen.getByRole('button', { name: /add account/i }))
+
+    expect(addAccount).toHaveBeenCalledTimes(1)
+    const payload = addAccount.mock.calls[0][0]
+    expect(payload.username).toBe('smurf1')
+    expect(payload.password).toBe('pw123')
+    expect(payload.networkId).toBe('riot')
+    expect(payload.displayName).toBe('smurf1') // defaults to username
+    expect(payload.games).toEqual(['lol', 'tft', 'valorant']) // defaults to all network games
+    expect(payload.region).toBe('na1')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('Back button returns to previous step without losing data', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    await user.click(screen.getByRole('button', { name: /back/i }))
+
+    expect(screen.getByPlaceholderText('Enter username')).toHaveValue('smurf1')
+    expect(screen.getByPlaceholderText('Enter password')).toHaveValue('pw')
+  })
+})


### PR DESCRIPTION
## Summary
- Replace the single-page Add Account form with a 3-step wizard that asks for just enough information per step, per product direction.
- Edit flow is untouched (users editing already know all the fields, so a single page is faster for them).
- Ships with a visual tile picker + fuzzy search for network selection, which extends cleanly when Steam/Epic land.

## Step flow
1. **Identity** — Username + Password (required), Display Name (optional)
2. **Network** — Visual tile grid, fuzzy-searchable. Each tile shows brand-colored Lucide icon, network name, and game count.
3. **Details** — Network-specific fields. For Riot: Region, Games (tile picker with its own search), Riot ID. Plus optional Notes. All fields have sensible defaults (displayName → username, games → all games on the network, region → na1) so a user can skip straight to **Add Account**.

## Design choices
- **Icons**: `GameNetwork` and `Game` have no icon field in the Go models and there are no game assets in the repo. Used Lucide icons keyed by ID with brand-color tiles (Riot red, LoL blue, TFT purple, Valorant rose). Swapping to real art is a non-blocking follow-up — just populate a `GAME_VISUAL` / `NETWORK_VISUAL` map entry.
- **Fuzzy search**: Subsequence match (`"lol"` → `"League of Legends"`, `"leag"` → same). Scales fine for <20 items; no fuse.js dep.
- **Reused component**: The `Tile` + search pattern is used for both network and game selection in a single file for now. If we add a third use, extract to its own component.
- **Validation**: Next is disabled until the step's minimum requirements are met; step 3 is always submittable.

## Changes
- `frontend/src/components/AddAccountWizard.tsx` — new component (3 steps + `fuzzyMatch` + `Tile`).
- `frontend/src/components/AccountList.tsx` — route Add → `AddAccountWizard`, Edit → `AccountModal`.
- `frontend/src/components/__tests__/AddAccountWizard.test.tsx` — 5 behavior tests + 3 `fuzzyMatch` tests.
- `frontend/src/test/setup.ts` — `afterEach(cleanup)` so multi-render tests don't leak DOM.

## Test plan
- [ ] CI: frontend build + 10/10 vitest pass
- [ ] Manual (`wails dev`): open **Add Account** → step indicator shows 1/3 → enter creds → **Next** enabled only after both filled → step 2 → search "ste" filters to Steam when applicable → pick Riot tile → step 3 → games as tiles, fuzzy search works → **Add Account** creates the account
- [ ] Manual: **Back** from each step preserves entered data
- [ ] Manual: skip step 3 entirely (empty) → account created with sensible defaults
- [ ] Manual: Edit flow (pencil icon on an existing account) still uses the single-page form as before
- [ ] Manual: visually inspect tile styling matches app theme in dark mode

## Follow-ups (out of scope here)
- Real game/network icon art instead of Lucide placeholders (needs asset work + schema change)
- Password visibility toggle on step 1
- Tag picker on step 3 (currently only notes; tags UX from the old modal isn't carried over to keep this PR focused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)