### PR TITLE
feat: wizard polish — masked password, opt-out games, tag picker

### DIFF
--- a/frontend/src/components/AddAccountWizard.tsx
+++ b/frontend/src/components/AddAccountWizard.tsx
@@ -8,6 +8,7 @@ import {
   Crosshair,
   Sparkles,
   Flame,
+  Plus,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAppStore } from '../stores/appStore'
@@ -102,12 +103,6 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
   const submit = async () => {
     setSubmitting(true)
     try {
-      const selectedNetwork = gameNetworks.find((n) => n.id === data.networkId)
-      // Default games to all games in the selected network if none picked
-      const games =
-        data.games.length > 0
-          ? data.games
-          : selectedNetwork?.games.map((g) => g.id) || []
       await addAccount({
         displayName: data.displayName || data.username,
         username: data.username,
@@ -117,7 +112,7 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
         notes: data.notes,
         riotId: data.riotId,
         region: data.region,
-        games,
+        games: data.games,
         cachedRanks: [],
       })
       onClose()
@@ -129,6 +124,15 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
   const update = <K extends keyof WizardData>(key: K, value: WizardData[K]) =>
     setData((prev) => ({ ...prev, [key]: value }))
 
+  // Picking a network pre-selects all its games (opt-out UX > opt-in).
+  // Switching to a different network resets to that network's full set.
+  const selectNetwork = (network: models.GameNetwork) =>
+    setData((prev) =>
+      prev.networkId === network.id
+        ? prev
+        : { ...prev, networkId: network.id, games: network.games.map((g) => g.id) },
+    )
+
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50">
       <div className="w-full max-w-[95%] sm:max-w-md bg-[var(--color-card)] rounded-xl sm:rounded-2xl border border-[var(--color-border)] overflow-hidden shadow-2xl max-h-[90vh] flex flex-col">
@@ -137,7 +141,7 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
         <div className="p-3 sm:p-4 overflow-y-auto flex-1 space-y-3 sm:space-y-4">
           {step === 'identity' && <IdentityStep data={data} update={update} />}
           {step === 'network' && (
-            <NetworkStep data={data} update={update} networks={gameNetworks} />
+            <NetworkStep data={data} onSelectNetwork={selectNetwork} networks={gameNetworks} />
           )}
           {step === 'details' && (
             <DetailsStep data={data} update={update} networks={gameNetworks} />
@@ -236,7 +240,7 @@ function IdentityStep({
       </Field>
       <Field label="Password" required>
         <input
-          type="text"
+          type="password"
           value={data.password}
           onChange={(e) => update('password', e.target.value)}
           placeholder="Enter password"
@@ -258,11 +262,11 @@ function IdentityStep({
 
 function NetworkStep({
   data,
-  update,
+  onSelectNetwork,
   networks,
 }: {
   data: WizardData
-  update: <K extends keyof WizardData>(key: K, value: WizardData[K]) => void
+  onSelectNetwork: (network: models.GameNetwork) => void
   networks: models.GameNetwork[]
 }) {
   const [query, setQuery] = useState('')
@@ -300,7 +304,7 @@ function NetworkStep({
             <Tile
               key={n.id}
               selected={data.networkId === n.id}
-              onClick={() => update('networkId', n.id)}
+              onClick={() => onSelectNetwork(n)}
               visual={NETWORK_VISUAL[n.id] || DEFAULT_VISUAL}
               title={n.name}
               subtitle={`${n.games.length} game${n.games.length === 1 ? '' : 's'}`}
@@ -321,12 +325,31 @@ function DetailsStep({
   update: <K extends keyof WizardData>(key: K, value: WizardData[K]) => void
   networks: models.GameNetwork[]
 }) {
+  const { tags: availableTags, createTag } = useAppStore()
   const network = networks.find((n) => n.id === data.networkId)
   const [gameQuery, setGameQuery] = useState('')
+  const [newTag, setNewTag] = useState('')
   const filteredGames = useMemo(
     () => (network?.games || []).filter((g) => fuzzyMatch(gameQuery, g.name) || fuzzyMatch(gameQuery, g.id)),
     [network, gameQuery],
   )
+
+  const toggleTag = (tag: string) => {
+    const has = data.tags.includes(tag)
+    update('tags', has ? data.tags.filter((t) => t !== tag) : [...data.tags, tag])
+  }
+
+  const addNewTag = async () => {
+    const trimmed = newTag.trim()
+    if (!trimmed) return
+    if (!availableTags.includes(trimmed)) {
+      await createTag(trimmed)
+    }
+    if (!data.tags.includes(trimmed)) {
+      update('tags', [...data.tags, trimmed])
+    }
+    setNewTag('')
+  }
 
   const inputClass = cn(
     'w-full px-2.5 sm:px-3 py-2 rounded-lg sm:rounded-xl text-sm',
@@ -368,7 +391,7 @@ function DetailsStep({
             ))}
           </div>
           <p className="text-[11px] text-[var(--color-muted-foreground)] mt-1.5">
-            Leave empty to include all games on this network.
+            All games selected by default — deselect any you don't play.
           </p>
         </Field>
       )}
@@ -405,6 +428,64 @@ function DetailsStep({
           </Field>
         </>
       )}
+
+      <Field label="Tags">
+        {availableTags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {availableTags.map((tag) => {
+              const selected = data.tags.includes(tag)
+              return (
+                <button
+                  key={tag}
+                  type="button"
+                  onClick={() => toggleTag(tag)}
+                  aria-pressed={selected}
+                  className={cn(
+                    'px-2.5 py-1 rounded-full text-xs font-medium border transition-all',
+                    'flex items-center gap-1 active:scale-[0.97]',
+                    selected
+                      ? 'bg-[var(--color-primary)] text-white border-[var(--color-primary)] shadow-sm'
+                      : 'bg-[var(--color-muted)] text-[var(--color-muted-foreground)] border-[var(--color-border)] hover:text-[var(--color-foreground)] hover:border-[var(--color-muted-foreground)]/40',
+                  )}
+                >
+                  {selected && <Check className="w-3 h-3" />}
+                  {tag}
+                </button>
+              )
+            })}
+          </div>
+        )}
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newTag}
+            onChange={(e) => setNewTag(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                addNewTag()
+              }
+            }}
+            placeholder="Create a new tag"
+            aria-label="Create a new tag"
+            className={cn(inputClass, 'flex-1')}
+          />
+          <button
+            type="button"
+            onClick={addNewTag}
+            disabled={!newTag.trim()}
+            className={cn(
+              'px-3 rounded-lg sm:rounded-xl text-sm font-medium transition-colors',
+              'bg-[var(--color-muted)] hover:bg-[var(--color-border)]',
+              'text-[var(--color-foreground)] flex items-center gap-1',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            <Plus className="w-3.5 h-3.5" />
+            Add
+          </button>
+        </div>
+      </Field>
 
       <Field label="Notes">
         <textarea

--- a/frontend/src/components/__tests__/AddAccountWizard.test.tsx
+++ b/frontend/src/components/__tests__/AddAccountWizard.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 const addAccount = vi.fn()
+const createTag = vi.fn()
 
 vi.mock('../../stores/appStore', () => ({
   useAppStore: () => ({
@@ -22,7 +23,9 @@ vi.mock('../../stores/appStore', () => ({
         games: [{ id: 'cs2', name: 'Counter-Strike 2', networkId: 'steam' }],
       },
     ],
+    tags: ['main', 'smurf'],
     addAccount,
+    createTag,
   }),
 }))
 
@@ -48,6 +51,13 @@ describe('fuzzyMatch', () => {
 describe('AddAccountWizard', () => {
   beforeEach(() => {
     addAccount.mockReset()
+    createTag.mockReset()
+  })
+
+  it('masks the password field with type="password"', () => {
+    render(<AddAccountWizard onClose={vi.fn()} />)
+    const pw = screen.getByPlaceholderText('Enter password') as HTMLInputElement
+    expect(pw.type).toBe('password')
   })
 
   it('requires username and password before advancing from step 1', async () => {
@@ -124,6 +134,60 @@ describe('AddAccountWizard', () => {
     expect(payload.games).toEqual(['lol', 'tft', 'valorant']) // defaults to all network games
     expect(payload.region).toBe('na1')
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('pre-selects all games when a network is picked (opt-out UX)', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+    await user.click(screen.getByRole('button', { name: /riot games/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // On step 3 every Riot game tile should already be selected.
+    expect(screen.getByRole('button', { name: /league of legends/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: /teamfight tactics/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+    expect(screen.getByRole('button', { name: /valorant/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
+  })
+
+  it('lets the user toggle existing tags and create new ones', async () => {
+    const user = userEvent.setup()
+    createTag.mockResolvedValue(undefined)
+    const onClose = vi.fn()
+    render(<AddAccountWizard onClose={onClose} />)
+
+    // Advance to step 3
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+    await user.click(screen.getByRole('button', { name: /riot games/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Toggle existing tag
+    await user.click(screen.getByRole('button', { name: /main/i }))
+
+    // Create a brand new tag via Enter key
+    const tagInput = screen.getByLabelText(/create a new tag/i)
+    await user.type(tagInput, 'ranked-grind{Enter}')
+
+    expect(createTag).toHaveBeenCalledWith('ranked-grind')
+    expect(tagInput).toHaveValue('')
+
+    await user.click(screen.getByRole('button', { name: /add account/i }))
+
+    expect(addAccount).toHaveBeenCalledTimes(1)
+    expect(addAccount.mock.calls[0][0].tags).toEqual(['main', 'ranked-grind'])
   })
 
   it('Back button returns to previous step without losing data', async () => {


### PR DESCRIPTION
## Summary
Three small UX improvements on top of the Add Account wizard (v1.2.3):

1. **Password masking** — Step 1 password input is now `type="password"` so characters show as obfuscated dots.
2. **Opt-out game selection** — When a user picks a network, all of its games are pre-selected. Users deselect games they don't play instead of hunting-and-pecking to opt into each. Switching networks resets to the new network's full set. Copy on step 3 updated: *"All games selected by default — deselect any you don't play."*
3. **Tag picker** — Step 3 now has a proper tag selector: pill-style buttons for every existing tag (selected = primary color with check icon, unselected = muted outline), plus an inline "Create a new tag" input that accepts Enter to create-and-select.

Also removed the fallback `games = allNetworkGames` logic at submit time since pre-selection makes it redundant — if a user deliberately deselects all, we now respect that (valid state: account exists but matches no game filter).

## Changes
- `frontend/src/components/AddAccountWizard.tsx`
  - `selectNetwork` handler sets `networkId` + `games` together; passed to `NetworkStep` in place of the generic `update`.
  - Password input → `type="password"`.
  - `DetailsStep` pulls `tags` + `createTag` from store; renders tag pills + create input with Enter-to-submit.
- `frontend/src/components/__tests__/AddAccountWizard.test.tsx` — +3 tests (password-type, pre-selected games, tag toggle + create). 16/16 pass.

## Test plan
- [x] CI: 16/16 vitest + frontend build pass
- [ ] Manual (`wails dev`): open Add → step 1 password shows as dots
- [ ] Manual: pick Riot on step 2 → advance → all 3 Riot games already selected on step 3
- [ ] Manual: deselect a game → advance → account stores only the remaining games
- [ ] Manual: tag pills render; clicking toggles selection; creating a new tag via input or Enter works and selects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)