### PR TITLE
feat: UI redesign + custom networks + telemetry + test coverage

### DIFF
--- a/app.go
+++ b/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"OpenSmurfManager/internal/accounts"
 	"OpenSmurfManager/internal/models"
@@ -12,6 +13,7 @@ import (
 	"OpenSmurfManager/internal/providers/riot"
 	"OpenSmurfManager/internal/riotapi"
 	"OpenSmurfManager/internal/storage"
+	"OpenSmurfManager/internal/telemetry"
 	"OpenSmurfManager/internal/updater"
 
 	"github.com/wailsapp/wails/v2/pkg/runtime"
@@ -24,6 +26,10 @@ type App struct {
 	accounts  *accounts.AccountService
 	updater   *updater.Updater
 	providers *providers.Registry
+
+	// startTime is set by main() before Wails.Run so startup() can report
+	// cold-boot latency in the app.start telemetry event.
+	startTime time.Time
 }
 
 // NewApp creates a new App application struct
@@ -49,6 +55,18 @@ func (a *App) startup(ctx context.Context) {
 	// MustRegister call here.
 	a.providers = providers.NewRegistry()
 	a.providers.MustRegister(riot.New())
+
+	// App-start latency = time from main() to Wails runtime ready.
+	// Separately emit has_vault so DAU/MAU queries can distinguish
+	// brand-new installs from returning users.
+	var latencyMs int64
+	if !a.startTime.IsZero() {
+		latencyMs = time.Since(a.startTime).Milliseconds()
+	}
+	telemetry.LogInfo("app.start", map[string]interface{}{
+		"startup_latency_ms": latencyMs,
+		"has_vault":          a.storage.VaultExists(),
+	})
 }
 
 // ============================================
@@ -84,7 +102,9 @@ func (a *App) CreateVaultWithRecoveryPhrase(username, masterPassword, hint strin
 
 // Unlock decrypts the vault with username and master password
 func (a *App) Unlock(username, masterPassword string) error {
-	return a.storage.Unlock(username, masterPassword)
+	err := a.storage.Unlock(username, masterPassword)
+	telemetry.LogInfo("vault.unlock", map[string]interface{}{"success": err == nil})
+	return err
 }
 
 // GetPasswordHint returns the password hint (available without unlocking)
@@ -139,6 +159,7 @@ func (a *App) GetStoredUsername() (string, error) {
 // Lock clears the vault from memory
 func (a *App) Lock() {
 	a.storage.Lock()
+	telemetry.LogInfo("vault.lock", nil)
 }
 
 // GetVaultPath returns the path to the vault file
@@ -177,17 +198,31 @@ func (a *App) SearchAccounts(query string) ([]models.Account, error) {
 
 // CreateAccount creates a new account
 func (a *App) CreateAccount(account models.Account) (*models.Account, error) {
-	return a.accounts.Create(account)
+	result, err := a.accounts.Create(account)
+	telemetry.LogInfo("account.add", map[string]interface{}{
+		"network_id":  account.NetworkID,
+		"games_count": len(account.Games),
+		"tags_count":  len(account.Tags),
+		"success":     err == nil,
+	})
+	return result, err
 }
 
 // UpdateAccount updates an existing account
 func (a *App) UpdateAccount(account models.Account) (*models.Account, error) {
-	return a.accounts.Update(account)
+	result, err := a.accounts.Update(account)
+	telemetry.LogInfo("account.edit", map[string]interface{}{
+		"network_id": account.NetworkID,
+		"success":    err == nil,
+	})
+	return result, err
 }
 
 // DeleteAccount removes an account
 func (a *App) DeleteAccount(id string) error {
-	return a.accounts.Delete(id)
+	err := a.accounts.Delete(id)
+	telemetry.LogInfo("account.delete", map[string]interface{}{"success": err == nil})
+	return err
 }
 
 // UpdateAccountRank updates rank info for an account
@@ -248,7 +283,19 @@ func (a *App) UpdateSettings(settings models.Settings) error {
 // registered platform provider. Returns the detected account info with ranks,
 // or nil if no supported client is running.
 func (a *App) DetectSignedInAccount() (*providers.DetectedAccount, error) {
-	return a.providers.DetectAny(a.ctx)
+	start := time.Now()
+	detected, err := a.providers.DetectAny(a.ctx)
+	result := "none"
+	if err != nil {
+		result = "error"
+	} else if detected != nil {
+		result = "detected"
+	}
+	telemetry.LogInfo("account.detect", map[string]interface{}{
+		"result":       result,
+		"duration_ms":  time.Since(start).Milliseconds(),
+	})
+	return detected, err
 }
 
 // IsInGame checks if the user is currently in an active game (not just client/lobby)
@@ -460,4 +507,32 @@ func (a *App) DownloadAndInstallUpdate(downloadURL string) error {
 // OpenReleasePage opens the GitHub release page in browser
 func (a *App) OpenReleasePage(url string) error {
 	return a.updater.OpenReleasePage(url)
+}
+
+// ============================================
+// Telemetry bridge (exposed to frontend)
+// ============================================
+
+// LogEvent records a UI-layer telemetry event. Level must be one of
+// "info", "warn", "error" (anything else is treated as info). Attributes
+// are stringly-typed at this boundary for simple Wails bindings; the
+// Go-side logger widens them into the OTel attribute shape.
+//
+// Callers must never pass credentials, usernames, or other vault data.
+// The frontend wrapper in lib/telemetry.ts holds the whitelist.
+func (a *App) LogEvent(level, event string, attributes map[string]string) {
+	attrs := make(map[string]interface{}, len(attributes)+1)
+	for k, v := range attributes {
+		attrs[k] = v
+	}
+	attrs["source"] = "frontend"
+
+	switch strings.ToLower(level) {
+	case "error":
+		telemetry.LogError(event, attrs)
+	case "warn":
+		telemetry.Log(telemetry.SeverityWarn, event, attrs)
+	default:
+		telemetry.LogInfo(event, attrs)
+	}
 }

--- a/app.go
+++ b/app.go
@@ -466,13 +466,14 @@ func (a *App) IsAnyClientRunning() bool {
 // Window Management (exposed to frontend)
 // ============================================
 
-// SetWindowSizeLogin sets the window to login/compact size (vertical)
+// SetWindowSizeLogin sets the window to login size. Same dimensions as the
+// main dashboard so unlocking doesn't trigger a jarring resize.
 func (a *App) SetWindowSizeLogin() {
-	runtime.WindowSetMinSize(a.ctx, 380, 650)
-	runtime.WindowSetSize(a.ctx, 380, 700)
+	runtime.WindowSetMinSize(a.ctx, 520, 760)
+	runtime.WindowSetSize(a.ctx, 520, 760)
 }
 
-// SetWindowSizeMain sets the window to main/dashboard size (horizontal)
+// SetWindowSizeMain sets the window to main/dashboard size.
 func (a *App) SetWindowSizeMain() {
 	runtime.WindowSetMinSize(a.ctx, 520, 760)
 	runtime.WindowSetSize(a.ctx, 520, 760)

--- a/docker/elk/README.md
+++ b/docker/elk/README.md
@@ -1,0 +1,83 @@
+# Local ELK Stack
+
+Kibana dashboards backed by your own OpenSmurfManager telemetry, running
+entirely on your machine. Use this to iterate on queries and dashboards
+while the hosted telemetry endpoint is still in the backlog.
+
+## What it runs
+
+- **Elasticsearch** 8.13.4 (single node, security off) — port 9200
+- **Kibana** 8.13.4 — port 5601
+- **Filebeat** 8.13.4 — tails the JSON-lines log files the desktop app
+  writes and ships them to Elasticsearch as documents in the
+  `osm-logs-YYYY.MM.DD` index
+
+Requires Docker Desktop (or an equivalent) with file sharing enabled for
+the drive containing your logs.
+
+## Wire up your logs directory
+
+The desktop client writes to `%APPDATA%\OpenSmurfManager\logs\` on
+Windows. Point the stack at it via the `OSM_LOGS_DIR` env var.
+
+**PowerShell:**
+
+```powershell
+$env:OSM_LOGS_DIR = "$env:APPDATA\OpenSmurfManager\logs"
+docker compose -f docker/elk/docker-compose.yml up -d
+```
+
+**Git Bash / WSL:**
+
+```bash
+export OSM_LOGS_DIR="$APPDATA/OpenSmurfManager/logs"
+docker compose -f docker/elk/docker-compose.yml up -d
+```
+
+If the env var is unset the compose file falls back to a placeholder dir
+and Filebeat will simply find nothing.
+
+## First view
+
+1. Launch the desktop app once so it writes at least one `app.start`
+   record.
+2. Open http://localhost:5601
+3. Stack Management → Data Views → create a view with index pattern
+   `osm-logs-*` and timestamp field `@timestamp`.
+4. Discover → the `body` field is the event name (`app.start`,
+   `vault.unlock`, `account.add`, …). Resource fields live under
+   `resource.*` (e.g. `resource.client.id` for DAU/MAU, `resource.os.type`
+   for platform split).
+
+## Useful starter queries
+
+```
+body: "app.start"
+body: ("account.add" OR "account.edit" OR "account.delete")
+attributes.success: false
+```
+
+DAU example (last 24h):
+
+```
+body: "app.start"
+| stats cardinality(resource.client.id)
+```
+
+(expressed in Kibana's UI as a metric panel with a `Unique count` of
+`resource.client.id`).
+
+## Stopping / resetting
+
+```bash
+docker compose -f docker/elk/docker-compose.yml down          # stop
+docker compose -f docker/elk/docker-compose.yml down -v       # stop + drop indexed data
+```
+
+## What this is **not**
+
+- Not a production telemetry target. Filebeat can only tail files on the
+  host it runs on — remote users' events stay on their machines until
+  the client grows an HTTP shipper.
+- No authentication / TLS on Elasticsearch. Do not expose these ports
+  beyond localhost.

--- a/docker/elk/docker-compose.yml
+++ b/docker/elk/docker-compose.yml
@@ -1,0 +1,58 @@
+# Local ELK stack for visualising OpenSmurfManager telemetry.
+#
+# Filebeat tails the logs directory on the host (set via OSM_LOGS_DIR, see
+# README.md), ships JSON-line events into Elasticsearch, and Kibana is
+# available at http://localhost:5601 for querying and dashboarding.
+#
+# This is a *local development* setup. It assumes the logs directory is
+# on the same machine as the ELK stack — fine for iterating on queries
+# and dashboards, not for observing real end-users. When you want fleet
+# data, replace Filebeat with an HTTP OTLP sink in the client.
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+    container_name: osm-elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.13.4
+    container_name: osm-kibana
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:8.13.4
+    container_name: osm-filebeat
+    user: root
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    command: filebeat -e -strict.perms=false
+    volumes:
+      - ./filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      # OSM_LOGS_DIR points at the host path containing app.log (+ rotated
+      # backups). On Windows the default is %APPDATA%\OpenSmurfManager\logs.
+      - "${OSM_LOGS_DIR:-./placeholder-logs}:/var/log/osm:ro"
+      - filebeat_data:/usr/share/filebeat/data
+
+volumes:
+  es_data:
+  filebeat_data:

--- a/docker/elk/filebeat.yml
+++ b/docker/elk/filebeat.yml
@@ -1,0 +1,28 @@
+filebeat.inputs:
+  - type: filestream
+    id: osm-logs
+    paths:
+      - /var/log/osm/app.log
+      - /var/log/osm/app.log.*
+    parsers:
+      # Each line is one OTel-shaped JSON record; expand into top-level
+      # fields so Kibana queries can use severityText, body, etc. directly.
+      - ndjson:
+          target: ""
+          overwrite_keys: true
+          add_error_key: true
+          ignore_decoding_error: true
+
+# Disable ILM / index templates so the dev stack doesn't need extra setup.
+setup.ilm.enabled: false
+setup.template.name: osm-logs
+setup.template.pattern: "osm-logs-*"
+setup.template.enabled: true
+setup.template.overwrite: true
+
+output.elasticsearch:
+  hosts: ["http://elasticsearch:9200"]
+  # Daily index so retention is easy to manage later.
+  index: "osm-logs-%{+yyyy.MM.dd}"
+
+logging.level: info

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from './stores/appStore'
 import { UnlockScreen } from './components/UnlockScreen'
 import { AccountList } from './components/AccountList'
 import { UpdateModal } from './components/UpdateModal'
+import { WindowFrame } from './components/WindowFrame'
 import './style.css'
 
 function App() {
@@ -40,34 +41,33 @@ function App() {
     return () => clearInterval(interval)
   }, [appState, settings?.autoCheckUpdates])
 
-  // Loading state
-  if (appState === 'loading') {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-[var(--color-background)]">
-        <div className="text-center">
-          <div className="w-12 h-12 border-4 border-[var(--color-primary)]/30 border-t-[var(--color-primary)] rounded-full animate-spin mx-auto"></div>
-          <p className="mt-4 text-[var(--color-muted-foreground)]">Loading...</p>
+  // Every screen sits under the custom window frame so chrome feels
+  // continuous with the app instead of hanging off a native title bar.
+  const screen = (() => {
+    if (appState === 'loading') {
+      return (
+        <div className="flex-1 flex items-center justify-center bg-[var(--color-background)]">
+          <div className="text-center">
+            <div className="w-12 h-12 border-4 border-[var(--color-primary)]/30 border-t-[var(--color-primary)] rounded-full animate-spin mx-auto"></div>
+            <p className="mt-4 text-[var(--color-muted-foreground)]">Loading...</p>
+          </div>
         </div>
-      </div>
-    )
-  }
+      )
+    }
+    if (appState === 'locked' || appState === 'create') {
+      return <UnlockScreen />
+    }
+    return <AccountList />
+  })()
 
-  // Locked or Create states - also show UpdateModal here
-  if (appState === 'locked' || appState === 'create') {
-    return (
-      <>
-        <UnlockScreen />
-        <UpdateModal />
-      </>
-    )
-  }
-
-  // Unlocked state
   return (
-    <>
-      <AccountList />
+    <div className="h-screen flex flex-col bg-[var(--color-background)] overflow-hidden">
+      <WindowFrame />
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+        {screen}
+      </div>
       <UpdateModal />
-    </>
+    </div>
   )
 }
 

--- a/frontend/src/components/AccountList.tsx
+++ b/frontend/src/components/AccountList.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { useAppStore } from '../stores/appStore'
 import {
   Search,
@@ -14,9 +14,18 @@ import {
   ChevronUp,
   ChevronDown,
   Settings,
+  Check as CheckIcon,
+  Volume2,
+  VolumeX,
 } from 'lucide-react'
 import { cn } from '../lib/utils'
+import { MOTION_BASE, MOTION_FOCUS } from '../lib/motion'
+import { getSoundsEnabled, setSoundsEnabled, playTick } from '../lib/sound'
 import { models, providers } from '../../wailsjs/go/models'
+import { Button } from './ui/Button'
+import { IconButton } from './ui/IconButton'
+import { Card } from './ui/Card'
+import { Modal, ModalBody, ModalFooter, ModalHeader } from './ui/Modal'
 import { RecoveryPhraseModal } from './RecoveryPhraseModal'
 import { SettingsModal } from './SettingsModal'
 import { AddAccountWizard } from './AddAccountWizard'
@@ -82,6 +91,7 @@ export function AccountList() {
     isDetecting,
     detectedAccount,
     activeAccountId,
+    showRecoveryPhraseModal,
     setSearchQuery,
     setSelectedNetwork,
     setSelectedTag,
@@ -98,7 +108,31 @@ export function AccountList() {
     () => allAccounts.some(a => a.networkId === 'custom'),
     [allAccounts],
   )
+  // Sound mute toggle — lives in the main header so it's always reachable,
+  // not buried inside Settings. Persists via sound.ts's localStorage.
+  const [soundsOn, setSoundsOn] = useState(getSoundsEnabled())
+  const toggleSounds = () => {
+    const next = !soundsOn
+    setSoundsEnabled(next)
+    setSoundsOn(next)
+    if (next) playTick() // confirmation pip on enable only
+  }
   const [showAddModal, setShowAddModal] = useState(false)
+  // Onboarding: drop first-time / zero-account users straight into the Add
+  // Account wizard so the happy-path setup is obvious without any copy
+  // telling them what to do. Offer once per session — if they dismiss, they
+  // land on the empty state and can add later via the Add Account button.
+  const [onboardingOffered, setOnboardingOffered] = useState(false)
+  useEffect(() => {
+    if (onboardingOffered) return
+    if (showRecoveryPhraseModal) return // PIN must be saved first
+    if (allAccounts.length > 0) {
+      setOnboardingOffered(true)
+      return
+    }
+    setShowAddModal(true)
+    setOnboardingOffered(true)
+  }, [allAccounts.length, showRecoveryPhraseModal, onboardingOffered])
   const [editingAccount, setEditingAccount] = useState<models.Account | null>(null)
   const [visiblePasswords, setVisiblePasswords] = useState<Set<string>>(new Set())
   const [copiedId, setCopiedId] = useState<string | null>(null)
@@ -188,7 +222,7 @@ export function AccountList() {
   }
 
   return (
-    <div className="h-screen flex flex-col bg-gradient-to-b from-[var(--color-background)] to-[var(--color-card)]">
+    <div className="flex-1 min-h-0 flex flex-col bg-gradient-to-b from-[var(--color-background)] to-[var(--color-card)]">
       {/* Header - Instagram-style clean header */}
       <header className="wails-drag flex items-center justify-between px-4 sm:px-5 lg:px-6 py-2.5 sm:py-3 bg-[var(--color-background)] border-b border-[var(--color-border)]/30 shrink-0">
         <div className="flex items-center gap-2.5 sm:gap-3">
@@ -205,7 +239,9 @@ export function AccountList() {
           </div>
         </div>
         <div className="flex items-center gap-1.5 sm:gap-2 shrink-0">
-          <button
+          <Button
+            size="sm"
+            variant="primary"
             onClick={async () => {
               const matchedId = await detectAndUpdateRanks()
               if (matchedId) {
@@ -215,28 +251,30 @@ export function AccountList() {
               }
             }}
             disabled={isDetecting}
-            className={cn(
-              'flex items-center gap-1.5 px-2.5 sm:px-3 py-1.5 rounded-md font-medium text-xs sm:text-sm',
-              'bg-[var(--color-primary)] text-white',
-              'hover:bg-[var(--color-primary)]/90 active:scale-[0.98]',
-              'transition-all duration-150',
-              'disabled:opacity-50 disabled:cursor-not-allowed'
-            )}
+            leadingIcon={
+              isDetecting ? (
+                <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+              ) : (
+                <Zap className="w-3.5 h-3.5" />
+              )
+            }
           >
-            {isDetecting ? (
-              <RefreshCw className="w-3.5 h-3.5 animate-spin" />
-            ) : (
-              <Zap className="w-3.5 h-3.5" />
-            )}
             <span className="hidden xs:inline">{isDetecting ? 'Detecting' : 'Detect'}</span>
-          </button>
-          <button
-            onClick={() => setShowSettingsModal(true)}
-            className="p-1.5 sm:p-2 rounded-md text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/30 transition-colors duration-150"
+          </Button>
+          <IconButton
+            ariaLabel={soundsOn ? 'Mute sounds' : 'Enable sounds'}
+            title={soundsOn ? 'Mute sounds' : 'Enable sounds'}
+            tone={soundsOn ? 'neutral' : 'brand'}
+            icon={soundsOn ? <Volume2 className="w-4 h-4" /> : <VolumeX className="w-4 h-4" />}
+            onClick={toggleSounds}
+          />
+          <IconButton
+            ariaLabel="Settings"
             title="Settings"
-          >
-            <Settings className="w-4 h-4" />
-          </button>
+            tone="neutral"
+            icon={<Settings className="w-4 h-4" />}
+            onClick={() => setShowSettingsModal(true)}
+          />
         </div>
       </header>
 
@@ -275,16 +313,13 @@ export function AccountList() {
                 Linked
               </span>
             ) : (
-              <button
+              <Button
+                size="sm"
                 onClick={() => setShowLinkModal(true)}
-                className={cn(
-                  "px-2.5 sm:px-3 py-1 sm:py-1.5 rounded-md text-xs font-medium shrink-0",
-                  "bg-amber-500 hover:bg-amber-400 text-black",
-                  "transition-colors duration-150"
-                )}
+                className="bg-amber-500 hover:bg-amber-400 text-black shadow-amber-500/25 hover:shadow-amber-500/40 shrink-0"
               >
                 Link
-              </button>
+              </Button>
             )}
           </div>
 
@@ -443,16 +478,11 @@ export function AccountList() {
                 const isActive = activeAccountId === account.id
 
                 return (
-                  <div
+                  <Card
                     key={account.id}
-                    className={cn(
-                      'p-4 sm:p-5 rounded-xl relative overflow-hidden',
-                      'bg-[var(--color-card)] border-2',
-                      isActive
-                        ? 'border-green-500/50 shadow-lg shadow-green-500/10'
-                        : 'border-[var(--color-border)]/40 hover:border-[var(--color-border)]/60',
-                      'transition-all duration-200'
-                    )}
+                    interactive
+                    active={isActive}
+                    className="p-4 sm:p-5"
                   >
                     {/* Active indicator bar */}
                     {isActive && (
@@ -488,18 +518,17 @@ export function AccountList() {
                         </div>
                       </div>
                       <div className="flex items-center gap-1 shrink-0 ml-2">
-                        <button
+                        <IconButton
+                          ariaLabel="Edit account"
+                          icon={<Pencil className="w-4 h-4" />}
                           onClick={() => setEditingAccount(account)}
-                          className="p-2 rounded-lg text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/30 transition-colors duration-150"
-                        >
-                          <Pencil className="w-4 h-4" />
-                        </button>
-                        <button
+                        />
+                        <IconButton
+                          ariaLabel="Delete account"
+                          tone="destructive"
+                          icon={<Trash2 className="w-4 h-4" />}
                           onClick={() => setDeletingAccount(account)}
-                          className="p-2 rounded-lg text-[var(--color-muted-foreground)] hover:text-red-400 hover:bg-red-500/10 transition-colors duration-150"
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
+                        />
                       </div>
                     </div>
 
@@ -510,40 +539,40 @@ export function AccountList() {
                         <code className="flex-1 text-sm bg-[var(--color-muted)]/30 px-2.5 py-1.5 rounded-md truncate font-medium">
                           {account.username}
                         </code>
-                        <button
-                          onClick={() => copyToClipboard(account.username, `${account.id}-user`)}
-                          className={cn(
-                            'p-1.5 rounded-md transition-colors duration-150 shrink-0',
+                        <IconButton
+                          ariaLabel="Copy username"
+                          size="sm"
+                          tone={copiedId === `${account.id}-user` ? 'success' : 'neutral'}
+                          icon={
                             copiedId === `${account.id}-user`
-                              ? 'text-green-400 bg-green-500/10'
-                              : 'text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/30'
-                          )}
-                        >
-                          <Copy className="w-3.5 h-3.5" />
-                        </button>
+                              ? <CheckIcon className="w-3.5 h-3.5" />
+                              : <Copy className="w-3.5 h-3.5" />
+                          }
+                          onClick={() => copyToClipboard(account.username, `${account.id}-user`)}
+                        />
                       </div>
                       <div className="flex items-center gap-2">
                         <span className="text-xs text-[var(--color-muted-foreground)] w-16 shrink-0">Password</span>
                         <code className="flex-1 text-sm bg-[var(--color-muted)]/30 px-2.5 py-1.5 rounded-md font-mono truncate">
                           {isPasswordVisible ? account.password : '••••••••'}
                         </code>
-                        <button
+                        <IconButton
+                          ariaLabel={isPasswordVisible ? 'Hide password' : 'Show password'}
+                          size="sm"
+                          icon={isPasswordVisible ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
                           onClick={() => togglePasswordVisibility(account.id)}
-                          className="p-1.5 rounded-md text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/30 transition-colors duration-150 shrink-0"
-                        >
-                          {isPasswordVisible ? <EyeOff className="w-3.5 h-3.5" /> : <Eye className="w-3.5 h-3.5" />}
-                        </button>
-                        <button
-                          onClick={() => copyToClipboard(account.password, `${account.id}-pass`)}
-                          className={cn(
-                            'p-1.5 rounded-md transition-colors duration-150 shrink-0',
+                        />
+                        <IconButton
+                          ariaLabel="Copy password"
+                          size="sm"
+                          tone={copiedId === `${account.id}-pass` ? 'success' : 'neutral'}
+                          icon={
                             copiedId === `${account.id}-pass`
-                              ? 'text-green-400 bg-green-500/10'
-                              : 'text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/30'
-                          )}
-                        >
-                          <Copy className="w-3.5 h-3.5" />
-                        </button>
+                              ? <CheckIcon className="w-3.5 h-3.5" />
+                              : <Copy className="w-3.5 h-3.5" />
+                          }
+                          onClick={() => copyToClipboard(account.password, `${account.id}-pass`)}
+                        />
                       </div>
                     </div>
 
@@ -602,7 +631,7 @@ export function AccountList() {
                         </div>
                       </div>
                     )}
-                  </div>
+                  </Card>
                 )
               })}
             </div>
@@ -613,19 +642,13 @@ export function AccountList() {
       {/* Add Button - Instagram-style floating action */}
       <div className="px-4 sm:px-6 lg:px-8 py-2.5 sm:py-3 bg-[var(--color-background)]/80 backdrop-blur-lg border-t border-[var(--color-border)]/20 shrink-0">
         <div className="max-w-4xl mx-auto flex justify-center">
-          <button
+          <Button
+            size="md"
+            leadingIcon={<Plus className="w-4 h-4" />}
             onClick={() => setShowAddModal(true)}
-            className={cn(
-              'px-5 sm:px-6 py-2 rounded-lg font-medium text-sm',
-              'bg-[var(--color-primary)] hover:bg-[var(--color-primary)]/90',
-              'text-white inline-flex items-center gap-1.5',
-              'hover:scale-[1.02] active:scale-[0.98]',
-              'transition-all duration-150 ease-out'
-            )}
           >
-            <Plus className="w-4 h-4" />
-            <span>Add Account</span>
-          </button>
+            Add Account
+          </Button>
         </div>
       </div>
 
@@ -822,18 +845,17 @@ function LinkAccountModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50">
-      <div className="w-full max-w-[95%] sm:max-w-md bg-[var(--color-card)] rounded-xl sm:rounded-2xl border border-[var(--color-border)] overflow-hidden shadow-2xl">
-        <div className="p-3 sm:p-4 border-b border-[var(--color-border)]">
-          <h2 className="text-base sm:text-lg font-bold text-[var(--color-foreground)]">
-            Link Riot Account
-          </h2>
-          <p className="text-xs sm:text-sm text-[var(--color-muted-foreground)] mt-1">
-            Connect <span className="font-semibold text-[var(--color-foreground)] break-all">{detectedAccount.RiotID}</span> to one of your saved accounts
-          </p>
-        </div>
+    <Modal onClose={onClose} size="md">
+      <ModalHeader>
+        <h2 className="text-base sm:text-lg font-bold text-[var(--color-foreground)]">
+          Link Riot Account
+        </h2>
+        <p className="text-xs sm:text-sm text-[var(--color-muted-foreground)] mt-1">
+          Connect <span className="font-semibold text-[var(--color-foreground)] break-all">{detectedAccount.RiotID}</span> to one of your saved accounts
+        </p>
+      </ModalHeader>
 
-        <div className="p-3 sm:p-4 space-y-2 sm:space-y-3 max-h-[50vh] sm:max-h-80 overflow-y-auto">
+      <div className="p-3 sm:p-4 space-y-2 sm:space-y-3 max-h-[50vh] sm:max-h-80 overflow-y-auto">
           {availableAccounts.length === 0 ? (
             <p className="text-xs sm:text-sm text-[var(--color-muted-foreground)] text-center py-4">
               All accounts are already linked to a Riot ID
@@ -884,28 +906,15 @@ function LinkAccountModal({
           )}
         </div>
 
-        <div className="p-3 sm:p-4 border-t border-[var(--color-border)] flex gap-2 sm:gap-3">
-          <button
-            type="button"
-            onClick={onClose}
-            className="flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm bg-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={handleLink}
-            disabled={!selectedId || linking}
-            className={cn(
-              'flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm transition-colors',
-              'bg-[var(--color-primary)] hover:bg-[var(--color-primary)]/90 text-white',
-              'disabled:opacity-50 disabled:cursor-not-allowed'
-            )}
-          >
-            {linking ? 'Linking...' : 'Link Account'}
-          </button>
-        </div>
-      </div>
-    </div>
+      <ModalFooter>
+        <Button fullWidth variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button fullWidth onClick={handleLink} disabled={!selectedId || linking}>
+          {linking ? 'Linking...' : 'Link Account'}
+        </Button>
+      </ModalFooter>
+    </Modal>
   )
 }
 
@@ -971,15 +980,14 @@ export function AccountModal({ account, onClose }: { account: models.Account | n
   }
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50">
-      <div className="w-full max-w-[95%] sm:max-w-md bg-[var(--color-card)] rounded-xl sm:rounded-2xl border border-[var(--color-border)] overflow-hidden shadow-2xl max-h-[90vh] flex flex-col">
-        <div className="p-3 sm:p-4 border-b border-[var(--color-border)] shrink-0">
-          <h2 className="text-base sm:text-lg font-bold text-[var(--color-foreground)]">
-            {account ? 'Edit Account' : 'Add Account'}
-          </h2>
-        </div>
+    <Modal onClose={onClose} size="md">
+      <ModalHeader>
+        <h2 className="text-base sm:text-lg font-bold text-[var(--color-foreground)]">
+          {account ? 'Edit Account' : 'Add Account'}
+        </h2>
+      </ModalHeader>
 
-        <form id="account-modal-form" onSubmit={handleSubmit} className="p-3 sm:p-4 space-y-3 sm:space-y-4 overflow-y-auto flex-1">
+      <form id="account-modal-form" onSubmit={handleSubmit} className="p-3 sm:p-4 space-y-3 sm:space-y-4 overflow-y-auto flex-1">
           <div className="space-y-1.5 sm:space-y-2">
             <label className="text-xs sm:text-sm font-medium text-[var(--color-foreground)]">
               Display Name
@@ -1251,34 +1259,25 @@ export function AccountModal({ account, onClose }: { account: models.Account | n
             />
           </div>
         </form>
-        <div className="p-3 sm:p-4 border-t border-[var(--color-border)] shrink-0 flex gap-2 sm:gap-3">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm bg-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              form="account-modal-form"
-              disabled={
-                loading ||
-                !formData.username ||
-                !formData.password ||
-                (formData.networkId === 'custom' && !formData.customNetwork.trim())
-              }
-              className={cn(
-                'flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm transition-colors',
-                'bg-[var(--color-primary)] hover:bg-[var(--color-primary)]/90 text-white',
-                'disabled:opacity-50 disabled:cursor-not-allowed'
-              )}
-            >
-              {loading ? 'Saving...' : (account ? 'Save' : 'Add')}
-            </button>
-          </div>
-      </div>
-    </div>
+      <ModalFooter>
+        <Button fullWidth variant="secondary" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          fullWidth
+          type="submit"
+          form="account-modal-form"
+          disabled={
+            loading ||
+            !formData.username ||
+            !formData.password ||
+            (formData.networkId === 'custom' && !formData.customNetwork.trim())
+          }
+        >
+          {loading ? 'Saving...' : (account ? 'Save' : 'Add')}
+        </Button>
+      </ModalFooter>
+    </Modal>
   )
 }
 
@@ -1306,47 +1305,32 @@ export function DeleteAccountModal({
   const label = account.displayName || account.username
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50">
-      <div className="w-full max-w-[95%] sm:max-w-sm bg-[var(--color-card)] rounded-xl sm:rounded-2xl border border-[var(--color-border)] overflow-hidden shadow-2xl flex flex-col">
-        <div className="p-3 sm:p-4 border-b border-[var(--color-border)] shrink-0 flex items-center gap-2 sm:gap-3">
-          <div className="w-8 h-8 sm:w-9 sm:h-9 rounded-full bg-red-500/10 flex items-center justify-center shrink-0">
-            <Trash2 className="w-4 h-4 sm:w-4.5 sm:h-4.5 text-red-400" />
-          </div>
-          <h2 className="text-base sm:text-lg font-bold text-[var(--color-foreground)]">
-            Delete account?
-          </h2>
+    <Modal onClose={onCancel} size="sm">
+      <ModalHeader className="flex items-center gap-2 sm:gap-3">
+        <div className="w-8 h-8 sm:w-9 sm:h-9 rounded-full bg-red-500/10 flex items-center justify-center shrink-0">
+          <Trash2 className="w-4 h-4 sm:w-4.5 sm:h-4.5 text-red-400" />
         </div>
+        <h2 className="text-base sm:text-lg font-bold text-[var(--color-foreground)]">
+          Delete account?
+        </h2>
+      </ModalHeader>
 
-        <div className="p-3 sm:p-4 text-sm text-[var(--color-muted-foreground)] space-y-2">
-          <p>
-            This will permanently delete{' '}
-            <span className="text-[var(--color-foreground)] font-medium">{label}</span>{' '}
-            from your vault. This cannot be undone.
-          </p>
-        </div>
+      <ModalBody className="text-sm text-[var(--color-muted-foreground)] space-y-2">
+        <p>
+          This will permanently delete{' '}
+          <span className="text-[var(--color-foreground)] font-medium">{label}</span>{' '}
+          from your vault. This cannot be undone.
+        </p>
+      </ModalBody>
 
-        <div className="p-3 sm:p-4 border-t border-[var(--color-border)] shrink-0 flex gap-2 sm:gap-3">
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={loading}
-            className="flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm bg-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={handleConfirm}
-            disabled={loading}
-            className={cn(
-              'flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm transition-colors text-white',
-              'bg-red-500 hover:bg-red-500/90 disabled:opacity-50 disabled:cursor-not-allowed',
-            )}
-          >
-            {loading ? 'Deleting...' : 'Delete'}
-          </button>
-        </div>
-      </div>
-    </div>
+      <ModalFooter>
+        <Button fullWidth variant="secondary" onClick={onCancel} disabled={loading}>
+          Cancel
+        </Button>
+        <Button fullWidth variant="destructive" onClick={handleConfirm} disabled={loading}>
+          {loading ? 'Deleting...' : 'Delete'}
+        </Button>
+      </ModalFooter>
+    </Modal>
   )
 }

--- a/frontend/src/components/AccountList.tsx
+++ b/frontend/src/components/AccountList.tsx
@@ -92,6 +92,12 @@ export function AccountList() {
   } = useAppStore()
 
   const unfilteredAccounts = filteredAccounts()
+  // Surface "Custom" in the network filter only when at least one account uses it —
+  // keeps the picker clean for users who haven't added custom networks yet.
+  const hasCustomAccounts = useMemo(
+    () => allAccounts.some(a => a.networkId === 'custom'),
+    [allAccounts],
+  )
   const [showAddModal, setShowAddModal] = useState(false)
   const [editingAccount, setEditingAccount] = useState<models.Account | null>(null)
   const [visiblePasswords, setVisiblePasswords] = useState<Set<string>>(new Set())
@@ -343,6 +349,7 @@ export function AccountList() {
             {gameNetworks.map(network => (
               <option key={network.id} value={network.id}>{network.name}</option>
             ))}
+            {hasCustomAccounts && <option value="custom">Custom</option>}
           </select>
 
           <select
@@ -425,6 +432,12 @@ export function AccountList() {
             <div className="space-y-3 sm:space-y-4">
               {accounts.map(account => {
                 const network = gameNetworks.find(n => n.id === account.networkId)
+                const isCustomNetwork = account.networkId === 'custom'
+                // Custom accounts store their label on the account itself since
+                // the network isn't in gameNetworks.
+                const networkLabel = isCustomNetwork
+                  ? (account.customNetwork || 'Custom')
+                  : network?.name
                 const isPasswordVisible = visiblePasswords.has(account.id)
                 // Check if this account is the currently signed-in one
                 const isActive = activeAccountId === account.id
@@ -470,7 +483,7 @@ export function AccountList() {
                             )}
                           </div>
                           <p className="text-xs sm:text-sm text-[var(--color-muted-foreground)] truncate mt-0.5">
-                            {account.riotId || network?.name || 'Gaming Account'}
+                            {account.riotId || networkLabel || 'Gaming Account'}
                           </p>
                         </div>
                       </div>
@@ -535,7 +548,7 @@ export function AccountList() {
                     </div>
 
                     {/* Tags & Games */}
-                    {(account.tags.length > 0 || (account.games && account.games.length > 0)) && (
+                    {(account.tags.length > 0 || (account.games && account.games.length > 0) || account.customGame) && (
                       <div className="flex items-center gap-2 mt-3 flex-wrap">
                         {account.games && account.games.map(gameId => (
                           <span
@@ -550,6 +563,11 @@ export function AccountList() {
                             {gameId === 'lol' ? 'League' : gameId === 'tft' ? 'TFT' : 'Valorant'}
                           </span>
                         ))}
+                        {isCustomNetwork && account.customGame && (
+                          <span className="px-2.5 py-1 text-xs rounded-md font-semibold bg-indigo-500/15 text-indigo-300 border border-indigo-500/20">
+                            {account.customGame}
+                          </span>
+                        )}
                         {account.tags.map(tag => (
                           <span
                             key={tag}
@@ -904,6 +922,8 @@ export function AccountModal({ account, onClose }: { account: models.Account | n
     riotId: account?.riotId || '',
     region: account?.region || 'na1',
     games: account?.games || ['lol', 'tft'],
+    customNetwork: account?.customNetwork || '',
+    customGame: account?.customGame || '',
   })
   const [newTag, setNewTag] = useState('')
   const [loading, setLoading] = useState(false)
@@ -1022,7 +1042,17 @@ export function AccountModal({ account, onClose }: { account: models.Account | n
             </label>
             <select
               value={formData.networkId}
-              onChange={(e) => setFormData(prev => ({ ...prev, networkId: e.target.value }))}
+              onChange={(e) => {
+                const next = e.target.value
+                setFormData(prev => ({
+                  ...prev,
+                  networkId: next,
+                  // Drop the other network's fields so we don't persist stale data
+                  ...(next === 'custom'
+                    ? { riotId: '', region: 'na1', games: [] }
+                    : { customNetwork: '', customGame: '' }),
+                }))
+              }}
               className={cn(
                 'w-full px-2.5 sm:px-3 py-2 rounded-lg sm:rounded-xl text-sm',
                 'bg-[var(--color-muted)] border border-[var(--color-border)]',
@@ -1033,8 +1063,50 @@ export function AccountModal({ account, onClose }: { account: models.Account | n
               {gameNetworks.map(network => (
                 <option key={network.id} value={network.id}>{network.name}</option>
               ))}
+              <option value="custom">Custom</option>
             </select>
           </div>
+
+          {/* Custom network fields */}
+          {formData.networkId === 'custom' && (
+            <>
+              <div className="space-y-1.5 sm:space-y-2">
+                <label className="text-xs sm:text-sm font-medium text-[var(--color-foreground)]">
+                  Network name *
+                </label>
+                <input
+                  type="text"
+                  value={formData.customNetwork}
+                  onChange={(e) => setFormData(prev => ({ ...prev, customNetwork: e.target.value }))}
+                  placeholder="e.g. Steam, Epic Games, Battle.net"
+                  required
+                  className={cn(
+                    'w-full px-2.5 sm:px-3 py-2 rounded-lg sm:rounded-xl text-sm',
+                    'bg-[var(--color-muted)] border border-[var(--color-border)]',
+                    'text-[var(--color-foreground)] placeholder:text-[var(--color-muted-foreground)]',
+                    'focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]'
+                  )}
+                />
+              </div>
+              <div className="space-y-1.5 sm:space-y-2">
+                <label className="text-xs sm:text-sm font-medium text-[var(--color-foreground)]">
+                  Game
+                </label>
+                <input
+                  type="text"
+                  value={formData.customGame}
+                  onChange={(e) => setFormData(prev => ({ ...prev, customGame: e.target.value }))}
+                  placeholder="Optional — e.g. CS2, Apex Legends"
+                  className={cn(
+                    'w-full px-2.5 sm:px-3 py-2 rounded-lg sm:rounded-xl text-sm',
+                    'bg-[var(--color-muted)] border border-[var(--color-border)]',
+                    'text-[var(--color-foreground)] placeholder:text-[var(--color-muted-foreground)]',
+                    'focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]'
+                  )}
+                />
+              </div>
+            </>
+          )}
 
           {/* Riot-specific fields - Responsive */}
           {formData.networkId === 'riot' && (
@@ -1190,7 +1262,12 @@ export function AccountModal({ account, onClose }: { account: models.Account | n
             <button
               type="submit"
               form="account-modal-form"
-              disabled={loading || !formData.username || !formData.password}
+              disabled={
+                loading ||
+                !formData.username ||
+                !formData.password ||
+                (formData.networkId === 'custom' && !formData.customNetwork.trim())
+              }
               className={cn(
                 'flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm transition-colors',
                 'bg-[var(--color-primary)] hover:bg-[var(--color-primary)]/90 text-white',

--- a/frontend/src/components/AddAccountWizard.tsx
+++ b/frontend/src/components/AddAccountWizard.tsx
@@ -9,6 +9,7 @@ import {
   Sparkles,
   Flame,
   Plus,
+  Puzzle,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAppStore } from '../stores/appStore'
@@ -25,8 +26,16 @@ type Step = 'identity' | 'network' | 'details'
 
 const STEPS: Step[] = ['identity', 'network', 'details']
 
+// Sentinel for user-defined networks we don't have first-class support for
+// (Steam, Epic, Battle.net, etc.). The user provides a label in step 3.
+export const CUSTOM_NETWORK_ID = 'custom'
+
 const NETWORK_VISUAL: Record<string, { icon: LucideIcon; color: string }> = {
   riot: { icon: Flame, color: 'text-red-400 bg-red-500/10 border-red-500/30' },
+  [CUSTOM_NETWORK_ID]: {
+    icon: Puzzle,
+    color: 'text-indigo-300 bg-indigo-500/10 border-indigo-500/30',
+  },
 }
 
 const GAME_VISUAL: Record<string, { icon: LucideIcon; color: string }> = {
@@ -60,6 +69,8 @@ type WizardData = {
   riotId: string
   region: string
   games: string[]
+  customNetwork: string
+  customGame: string
 }
 
 const EMPTY: WizardData = {
@@ -72,6 +83,8 @@ const EMPTY: WizardData = {
   riotId: '',
   region: 'na1',
   games: [],
+  customNetwork: '',
+  customGame: '',
 }
 
 export function AddAccountWizard({ onClose }: { onClose: () => void }) {
@@ -81,10 +94,14 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
   const [submitting, setSubmitting] = useState(false)
 
   const stepIndex = STEPS.indexOf(step)
+  // Custom network needs a user-provided name before submission — otherwise
+  // the account would show up as a nameless "Custom" in the list.
+  const customReady =
+    data.networkId !== CUSTOM_NETWORK_ID || data.customNetwork.trim().length > 0
   const canAdvance =
     (step === 'identity' && data.username.length > 0 && data.password.length > 0) ||
     (step === 'network' && data.networkId.length > 0) ||
-    step === 'details'
+    (step === 'details' && customReady)
 
   const goBack = () => {
     if (stepIndex > 0) setStep(STEPS[stepIndex - 1])
@@ -103,6 +120,7 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
   const submit = async () => {
     setSubmitting(true)
     try {
+      const isCustom = data.networkId === CUSTOM_NETWORK_ID
       await addAccount({
         displayName: data.displayName || data.username,
         username: data.username,
@@ -110,9 +128,12 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
         networkId: data.networkId,
         tags: data.tags,
         notes: data.notes,
-        riotId: data.riotId,
-        region: data.region,
-        games: data.games,
+        // Riot fields only meaningful for the Riot network
+        riotId: isCustom ? '' : data.riotId,
+        region: isCustom ? '' : data.region,
+        games: isCustom ? [] : data.games,
+        customNetwork: isCustom ? data.customNetwork.trim() : '',
+        customGame: isCustom ? data.customGame.trim() : '',
         cachedRanks: [],
       })
       onClose()
@@ -125,23 +146,42 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
     setData((prev) => ({ ...prev, [key]: value }))
 
   // Picking a network pre-selects all its games (opt-out UX > opt-in).
-  // Switching to a different network resets to that network's full set.
+  // Switching to a different network resets to that network's full set and
+  // clears any previously-entered custom-network fields.
   const selectNetwork = (network: models.GameNetwork) =>
     setData((prev) =>
       prev.networkId === network.id
         ? prev
-        : { ...prev, networkId: network.id, games: network.games.map((g) => g.id) },
+        : {
+            ...prev,
+            networkId: network.id,
+            games: network.games.map((g) => g.id),
+            customNetwork: '',
+            customGame: '',
+          },
+    )
+
+  // Custom path — no pre-selected games because we don't know what the
+  // network offers. User fills in the label on step 3.
+  const selectCustom = () =>
+    setData((prev) =>
+      prev.networkId === CUSTOM_NETWORK_ID ? prev : { ...prev, networkId: CUSTOM_NETWORK_ID, games: [] },
     )
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50">
       <div className="w-full max-w-[95%] sm:max-w-md bg-[var(--color-card)] rounded-xl sm:rounded-2xl border border-[var(--color-border)] overflow-hidden shadow-2xl max-h-[90vh] flex flex-col">
-        <WizardHeader step={step} />
+        <WizardHeader step={step} isCustom={data.networkId === CUSTOM_NETWORK_ID} />
 
         <div className="p-3 sm:p-4 overflow-y-auto flex-1 space-y-3 sm:space-y-4">
           {step === 'identity' && <IdentityStep data={data} update={update} />}
           {step === 'network' && (
-            <NetworkStep data={data} onSelectNetwork={selectNetwork} networks={gameNetworks} />
+            <NetworkStep
+              data={data}
+              onSelectNetwork={selectNetwork}
+              onSelectCustom={selectCustom}
+              networks={gameNetworks}
+            />
           )}
           {step === 'details' && (
             <DetailsStep data={data} update={update} networks={gameNetworks} />
@@ -176,11 +216,14 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
   )
 }
 
-function WizardHeader({ step }: { step: Step }) {
+function WizardHeader({ step, isCustom }: { step: Step; isCustom: boolean }) {
   const titles: Record<Step, { title: string; subtitle: string }> = {
     identity: { title: 'Add Account', subtitle: 'Start with your sign-in credentials' },
     network: { title: 'Choose Network', subtitle: 'Which platform is this account for?' },
-    details: { title: 'Finishing Touches', subtitle: 'All optional — skip to save' },
+    details: {
+      title: 'Finishing Touches',
+      subtitle: isCustom ? 'Name your platform and you\'re done' : 'All optional — skip to save',
+    },
   }
   const { title, subtitle } = titles[step]
   const stepIndex = STEPS.indexOf(step)
@@ -263,10 +306,12 @@ function IdentityStep({
 function NetworkStep({
   data,
   onSelectNetwork,
+  onSelectCustom,
   networks,
 }: {
   data: WizardData
   onSelectNetwork: (network: models.GameNetwork) => void
+  onSelectCustom: () => void
   networks: models.GameNetwork[]
 }) {
   const [query, setQuery] = useState('')
@@ -274,6 +319,15 @@ function NetworkStep({
     () => networks.filter((n) => fuzzyMatch(query, n.name) || fuzzyMatch(query, n.id)),
     [networks, query],
   )
+  // The Custom tile is the escape hatch for platforms we don't cover — show it
+  // whenever the query is empty or fuzzy-matches "custom"/"other" so it stays
+  // discoverable, especially when no real networks match.
+  const q = query.trim().toLowerCase()
+  const showCustom =
+    q.length === 0 ||
+    fuzzyMatch(query, 'Custom') ||
+    fuzzyMatch(query, 'Other') ||
+    filtered.length === 0
 
   return (
     <>
@@ -294,23 +348,32 @@ function NetworkStep({
         />
       </div>
 
-      {filtered.length === 0 ? (
-        <p className="text-sm text-[var(--color-muted-foreground)] text-center py-8">
-          No networks match "{query}".
+      <div className="grid grid-cols-2 gap-2 sm:gap-3">
+        {filtered.map((n) => (
+          <Tile
+            key={n.id}
+            selected={data.networkId === n.id}
+            onClick={() => onSelectNetwork(n)}
+            visual={NETWORK_VISUAL[n.id] || DEFAULT_VISUAL}
+            title={n.name}
+            subtitle={`${n.games.length} game${n.games.length === 1 ? '' : 's'}`}
+          />
+        ))}
+        {showCustom && (
+          <Tile
+            selected={data.networkId === CUSTOM_NETWORK_ID}
+            onClick={onSelectCustom}
+            visual={NETWORK_VISUAL[CUSTOM_NETWORK_ID]}
+            title="Custom"
+            subtitle="Not listed? Name your own"
+          />
+        )}
+      </div>
+
+      {filtered.length === 0 && q.length > 0 && (
+        <p className="text-xs text-[var(--color-muted-foreground)] text-center pt-1">
+          No match for "{query}" — add it as Custom.
         </p>
-      ) : (
-        <div className="grid grid-cols-2 gap-2 sm:gap-3">
-          {filtered.map((n) => (
-            <Tile
-              key={n.id}
-              selected={data.networkId === n.id}
-              onClick={() => onSelectNetwork(n)}
-              visual={NETWORK_VISUAL[n.id] || DEFAULT_VISUAL}
-              title={n.name}
-              subtitle={`${n.games.length} game${n.games.length === 1 ? '' : 's'}`}
-            />
-          ))}
-        </div>
       )}
     </>
   )
@@ -327,6 +390,7 @@ function DetailsStep({
 }) {
   const { tags: availableTags, createTag } = useAppStore()
   const network = networks.find((n) => n.id === data.networkId)
+  const isCustom = data.networkId === CUSTOM_NETWORK_ID
   const [gameQuery, setGameQuery] = useState('')
   const [newTag, setNewTag] = useState('')
   const filteredGames = useMemo(
@@ -365,7 +429,31 @@ function DetailsStep({
 
   return (
     <>
-      {network && network.games.length > 0 && (
+      {isCustom && (
+        <>
+          <Field label="Network name" required>
+            <input
+              type="text"
+              value={data.customNetwork}
+              onChange={(e) => update('customNetwork', e.target.value)}
+              placeholder="e.g. Steam, Epic Games, Battle.net"
+              autoFocus
+              className={inputClass}
+            />
+          </Field>
+          <Field label="Game">
+            <input
+              type="text"
+              value={data.customGame}
+              onChange={(e) => update('customGame', e.target.value)}
+              placeholder="Optional — e.g. CS2, Apex Legends, Overwatch"
+              className={inputClass}
+            />
+          </Field>
+        </>
+      )}
+
+      {!isCustom && network && network.games.length > 0 && (
         <Field label="Games">
           <div className="relative mb-2">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--color-muted-foreground)]" />

--- a/frontend/src/components/AddAccountWizard.tsx
+++ b/frontend/src/components/AddAccountWizard.tsx
@@ -14,6 +14,9 @@ import {
 import type { LucideIcon } from 'lucide-react'
 import { useAppStore } from '../stores/appStore'
 import { cn } from '../lib/utils'
+import { MOTION_BASE, MOTION_FOCUS } from '../lib/motion'
+import { Button } from './ui/Button'
+import { Modal, ModalBody, ModalFooter, ModalHeader } from './ui/Modal'
 import { models } from '../../wailsjs/go/models'
 
 // Progressive-disclosure add-account wizard.
@@ -169,50 +172,44 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
     )
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50">
-      <div className="w-full max-w-[95%] sm:max-w-md bg-[var(--color-card)] rounded-xl sm:rounded-2xl border border-[var(--color-border)] overflow-hidden shadow-2xl max-h-[90vh] flex flex-col">
-        <WizardHeader step={step} isCustom={data.networkId === CUSTOM_NETWORK_ID} />
+    <Modal onClose={onClose} size="md">
+      <WizardHeader step={step} isCustom={data.networkId === CUSTOM_NETWORK_ID} />
 
-        <div className="p-3 sm:p-4 overflow-y-auto flex-1 space-y-3 sm:space-y-4">
-          {step === 'identity' && <IdentityStep data={data} update={update} />}
-          {step === 'network' && (
-            <NetworkStep
-              data={data}
-              onSelectNetwork={selectNetwork}
-              onSelectCustom={selectCustom}
-              networks={gameNetworks}
-            />
-          )}
-          {step === 'details' && (
-            <DetailsStep data={data} update={update} networks={gameNetworks} />
-          )}
-        </div>
+      <ModalBody className="space-y-3 sm:space-y-4">
+        {step === 'identity' && <IdentityStep data={data} update={update} />}
+        {step === 'network' && (
+          <NetworkStep
+            data={data}
+            onSelectNetwork={selectNetwork}
+            onSelectCustom={selectCustom}
+            networks={gameNetworks}
+          />
+        )}
+        {step === 'details' && (
+          <DetailsStep data={data} update={update} networks={gameNetworks} />
+        )}
+      </ModalBody>
 
-        <div className="p-3 sm:p-4 border-t border-[var(--color-border)] shrink-0 flex gap-2 sm:gap-3">
-          <button
-            type="button"
-            onClick={goBack}
-            disabled={submitting}
-            className="flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm bg-[var(--color-muted)] hover:bg-[var(--color-border)] transition-colors disabled:opacity-50 flex items-center justify-center gap-1.5"
-          >
-            {stepIndex > 0 && <ChevronLeft className="w-4 h-4" />}
-            {stepIndex === 0 ? 'Cancel' : 'Back'}
-          </button>
-          <button
-            type="button"
-            onClick={goNext}
-            disabled={!canAdvance || submitting}
-            className={cn(
-              'flex-1 py-2 sm:py-2.5 rounded-lg sm:rounded-xl font-medium text-sm transition-colors text-white',
-              'bg-[var(--color-primary)] hover:bg-[var(--color-primary)]/90',
-              'disabled:opacity-50 disabled:cursor-not-allowed',
-            )}
-          >
-            {step === 'details' ? (submitting ? 'Adding...' : 'Add Account') : 'Next'}
-          </button>
-        </div>
-      </div>
-    </div>
+      <ModalFooter>
+        <Button
+          fullWidth
+          variant="secondary"
+          onClick={goBack}
+          disabled={submitting}
+          leadingIcon={stepIndex > 0 ? <ChevronLeft className="w-4 h-4" /> : undefined}
+        >
+          {stepIndex === 0 ? 'Cancel' : 'Back'}
+        </Button>
+        <Button
+          fullWidth
+          variant="primary"
+          onClick={goNext}
+          disabled={!canAdvance || submitting}
+        >
+          {step === 'details' ? (submitting ? 'Adding...' : 'Add Account') : 'Next'}
+        </Button>
+      </ModalFooter>
+    </Modal>
   )
 }
 
@@ -627,22 +624,26 @@ function Tile({
       type="button"
       onClick={onClick}
       className={cn(
-        'group relative flex flex-col items-center gap-2 p-3 sm:p-4 rounded-xl border-2 transition-all',
-        'hover:scale-[1.02] active:scale-[0.98]',
+        'group relative flex flex-col items-center gap-2 p-3 sm:p-4 rounded-xl border-2',
+        MOTION_BASE,
+        MOTION_FOCUS,
+        'hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.98] motion-reduce:hover:translate-y-0 motion-reduce:active:scale-100',
         selected
-          ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/5'
-          : 'border-[var(--color-border)] bg-[var(--color-muted)]/30 hover:border-[var(--color-muted-foreground)]/40',
+          ? 'border-[var(--color-primary)] bg-[var(--color-primary)]/5 shadow-[0_0_0_3px_var(--color-primary)]/10 ring-1 ring-[var(--color-primary)]/30'
+          : 'border-[var(--color-border)] bg-[var(--color-muted)]/30 hover:border-[var(--color-muted-foreground)]/40 hover:bg-[var(--color-muted)]/50 hover:shadow-md',
       )}
       aria-pressed={selected}
     >
       {selected && (
-        <span className="absolute top-1.5 right-1.5 w-5 h-5 rounded-full bg-[var(--color-primary)] flex items-center justify-center">
+        <span className="absolute top-1.5 right-1.5 w-5 h-5 rounded-full bg-[var(--color-primary)] flex items-center justify-center shadow-md shadow-[var(--color-primary)]/30 animate-pop-in">
           <Check className="w-3 h-3 text-white" />
         </span>
       )}
       <div
         className={cn(
           'w-10 h-10 sm:w-12 sm:h-12 rounded-lg flex items-center justify-center border',
+          MOTION_BASE,
+          'group-hover:scale-110 motion-reduce:group-hover:scale-100',
           visual.color,
         )}
       >

--- a/frontend/src/components/RecoveryPhraseModal.tsx
+++ b/frontend/src/components/RecoveryPhraseModal.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { useAppStore } from '../stores/appStore'
 import { Copy, Check, Shield, AlertTriangle } from 'lucide-react'
 import { cn } from '../lib/utils'
+import { Modal } from './ui/Modal'
+import { Button } from './ui/Button'
 
 export function RecoveryPhraseModal() {
   const { pendingRecoveryPhrase, showRecoveryPhraseModal, dismissRecoveryPhraseModal, requiresPinSetup } = useAppStore()
@@ -45,8 +47,8 @@ export function RecoveryPhraseModal() {
   const isFirstTime = requiresPinSetup
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-[var(--color-card)] rounded-xl shadow-xl max-w-md w-full p-6 space-y-6">
+    <Modal onClose={handleDismiss} dismissOnBackdrop={false} size="md">
+      <div className="p-6 space-y-6">
         {/* Header */}
         <div className="text-center">
           <div className="mx-auto w-12 h-12 bg-[var(--color-warning)]/20 rounded-full flex items-center justify-center mb-4">
@@ -131,15 +133,12 @@ export function RecoveryPhraseModal() {
 
         {/* Continue button - only shown after reveal */}
         {showPhrase && (
-          <button
-            onClick={handleDismiss}
-            className="w-full py-3 rounded-lg font-medium bg-[var(--color-primary)] hover:bg-[var(--color-primary)]/90 text-white cursor-pointer transition-all duration-200 animate-glow"
-          >
+          <Button fullWidth size="lg" onClick={handleDismiss}>
             I've Saved My Recovery PIN
-          </button>
+          </Button>
         )}
 
-        {/* Shimmer and glow animations */}
+        {/* Shimmer animation for reveal */}
         <style>{`
           .shimmer {
             background: linear-gradient(
@@ -155,16 +154,8 @@ export function RecoveryPhraseModal() {
             0% { background-position: 200% 0; }
             100% { background-position: -200% 0; }
           }
-          .animate-glow {
-            animation: glow 1s ease-in-out;
-          }
-          @keyframes glow {
-            0% { box-shadow: 0 0 0 0 rgba(var(--color-primary-rgb, 59, 130, 246), 0.5); }
-            50% { box-shadow: 0 0 20px 4px rgba(var(--color-primary-rgb, 59, 130, 246), 0.3); }
-            100% { box-shadow: 0 0 0 0 rgba(var(--color-primary-rgb, 59, 130, 246), 0); }
-          }
         `}</style>
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/frontend/src/components/SettingsModal.tsx
+++ b/frontend/src/components/SettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useAppStore } from '../stores/appStore'
 import {
   X,
@@ -28,6 +28,18 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   const { lock } = useAppStore()
   const [activeTab, setActiveTab] = useState<SettingsTab>('general')
 
+  // Esc to dismiss + body scroll lock, matching the Modal primitive's behaviour
+  useEffect(() => {
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = prev
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
   const tabs: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
     { id: 'general', label: 'General', icon: <User className="w-4 h-4" /> },
     { id: 'security', label: 'Security', icon: <Shield className="w-4 h-4" /> },
@@ -36,8 +48,14 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   ]
 
   return (
-    <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-      <div className="w-full max-w-2xl h-[500px] bg-[var(--color-card)] rounded-xl border border-[var(--color-border)] overflow-hidden shadow-2xl flex">
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-4 z-50 animate-fade-in"
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className="w-full max-w-2xl h-[500px] bg-[var(--color-card)] rounded-xl border border-[var(--color-border)] overflow-hidden shadow-2xl shadow-black/40 flex animate-scale-in relative before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/[0.06] before:pointer-events-none"
+      >
         {/* Sidebar */}
         <div className="w-48 bg-[var(--color-background)] border-r border-[var(--color-border)] flex flex-col">
           <div className="p-4 border-b border-[var(--color-border)]">
@@ -49,9 +67,9 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
                 className={cn(
-                  'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors',
+                  'w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-all duration-150 motion-reduce:transition-none active:scale-[0.98] motion-reduce:active:scale-100',
                   activeTab === tab.id
-                    ? 'bg-[var(--color-primary)] text-white'
+                    ? 'bg-[var(--color-primary)] text-white shadow-sm shadow-[var(--color-primary)]/25'
                     : 'text-[var(--color-muted-foreground)] hover:text-[var(--color-foreground)] hover:bg-[var(--color-muted)]/50'
                 )}
               >

--- a/frontend/src/components/UnlockScreen.tsx
+++ b/frontend/src/components/UnlockScreen.tsx
@@ -155,7 +155,7 @@ export function UnlockScreen() {
   // Recovery Mode UI
   if (isRecoveryMode) {
     return (
-      <div className="min-h-screen flex items-center justify-center p-4 bg-[var(--color-background)]">
+      <div className="flex-1 min-h-0 flex items-center justify-center p-4 bg-[var(--color-background)] overflow-y-auto">
         <div className="w-full max-w-md">
           {/* Header */}
           <div className="text-center mb-8">

--- a/frontend/src/components/WindowFrame.tsx
+++ b/frontend/src/components/WindowFrame.tsx
@@ -1,0 +1,89 @@
+import { Minus, Square, X, Gamepad2 } from 'lucide-react'
+import { cn } from '../lib/utils'
+import {
+  WindowMinimise,
+  WindowToggleMaximise,
+  Quit,
+} from '../../wailsjs/runtime/runtime'
+
+// Custom window title bar. Replaces the native Windows chrome so the app
+// reads as one continuous surface, the way Discord / VS Code / Slack /
+// Figma do it. Only visible because main.go sets `Frameless: true`.
+//
+// Interaction model:
+//   - The whole bar carries the `wails-drag` class (CSS var:
+//     --wails-draggable: drag). Clicking + dragging anywhere on it moves
+//     the window. No-drag children (logo text, buttons) explicitly opt out
+//     so they stay clickable.
+//   - Window controls call the Wails frontend runtime directly. They don't
+//     go through the Go bindings — less round-trip latency for chrome.
+
+export function WindowFrame() {
+  return (
+    <div
+      className={cn(
+        'wails-drag',
+        'h-9 shrink-0 flex items-center justify-between',
+        'bg-[var(--color-background)] border-b border-[var(--color-border)]/40',
+        'select-none pl-3',
+      )}
+    >
+      {/* Brand — tiny logo + name. style overrides the drag region so the
+          user can select text here (rare, but feels right). */}
+      <div className="flex items-center gap-2" style={{ ['--wails-draggable' as any]: 'no-drag' }}>
+        <Gamepad2 className="w-3.5 h-3.5 text-[var(--color-primary)]" />
+        <span className="text-xs font-semibold text-[var(--color-foreground)] tracking-tight">
+          SmurfManager
+        </span>
+      </div>
+
+      {/* Window controls — no-drag so clicks register. */}
+      <div className="flex items-stretch" style={{ ['--wails-draggable' as any]: 'no-drag' }}>
+        <ControlButton
+          ariaLabel="Minimise"
+          onClick={() => WindowMinimise()}
+          icon={<Minus className="w-3.5 h-3.5" />}
+        />
+        <ControlButton
+          ariaLabel="Maximise"
+          onClick={() => WindowToggleMaximise()}
+          icon={<Square className="w-3 h-3" />}
+        />
+        <ControlButton
+          ariaLabel="Close"
+          onClick={() => Quit()}
+          icon={<X className="w-3.5 h-3.5" />}
+          destructive
+        />
+      </div>
+    </div>
+  )
+}
+
+function ControlButton({
+  ariaLabel,
+  onClick,
+  icon,
+  destructive,
+}: {
+  ariaLabel: string
+  onClick: () => void
+  icon: React.ReactNode
+  destructive?: boolean
+}) {
+  return (
+    <button
+      aria-label={ariaLabel}
+      onClick={onClick}
+      className={cn(
+        'w-11 h-9 flex items-center justify-center transition-colors duration-100',
+        'text-[var(--color-muted-foreground)]',
+        destructive
+          ? 'hover:bg-red-500 hover:text-white'
+          : 'hover:bg-[var(--color-muted)] hover:text-[var(--color-foreground)]',
+      )}
+    >
+      {icon}
+    </button>
+  )
+}

--- a/frontend/src/components/__tests__/AccountList.test.tsx
+++ b/frontend/src/components/__tests__/AccountList.test.tsx
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// The store is fully mocked — AccountList is consumer-only. We drive scenarios
+// by swapping what the store returns per test.
+
+const setSelectedNetwork = vi.fn()
+const setSelectedTag = vi.fn()
+const setSearchQuery = vi.fn()
+const removeAccount = vi.fn()
+const detectAndUpdateRanks = vi.fn()
+const editAccount = vi.fn()
+const loadAccounts = vi.fn()
+const addAccount = vi.fn()
+const createTag = vi.fn()
+
+type StoreOverrides = Partial<{
+  accounts: any[]
+  filteredAccounts: any[]
+  showRecoveryPhraseModal: boolean
+  detectedAccount: any
+  activeAccountId: string | null
+  selectedNetworkId: string | null
+  selectedTag: string | null
+  searchQuery: string
+}>
+
+let currentOverrides: StoreOverrides = {}
+
+vi.mock('../../stores/appStore', () => ({
+  useAppStore: () => {
+    const accounts = currentOverrides.accounts ?? []
+    const filtered = currentOverrides.filteredAccounts ?? accounts
+    return {
+      filteredAccounts: () => filtered,
+      accounts,
+      gameNetworks: [
+        {
+          id: 'riot',
+          name: 'Riot Games',
+          games: [
+            { id: 'lol', name: 'League of Legends', networkId: 'riot' },
+            { id: 'tft', name: 'Teamfight Tactics', networkId: 'riot' },
+            { id: 'valorant', name: 'Valorant', networkId: 'riot' },
+          ],
+        },
+      ],
+      tags: ['main', 'smurf'],
+      searchQuery: currentOverrides.searchQuery ?? '',
+      selectedNetworkId: currentOverrides.selectedNetworkId ?? null,
+      selectedTag: currentOverrides.selectedTag ?? null,
+      username: 'eren',
+      isDetecting: false,
+      detectedAccount: currentOverrides.detectedAccount ?? null,
+      activeAccountId: currentOverrides.activeAccountId ?? null,
+      showRecoveryPhraseModal: currentOverrides.showRecoveryPhraseModal ?? false,
+      setSearchQuery,
+      setSelectedNetwork,
+      setSelectedTag,
+      removeAccount,
+      detectAndUpdateRanks,
+      editAccount,
+      loadAccounts,
+      addAccount,
+      createTag,
+    }
+  },
+}))
+
+// Stub children that aren't under test to keep render cheap and isolated.
+vi.mock('../RecoveryPhraseModal', () => ({ RecoveryPhraseModal: () => null }))
+vi.mock('../SettingsModal', () => ({ SettingsModal: () => null }))
+
+import { AccountList } from '../AccountList'
+
+function render_withOverrides(overrides: StoreOverrides = {}) {
+  currentOverrides = overrides
+  return render(<AccountList />)
+}
+
+function makeAccount(partial: any = {}) {
+  return {
+    id: partial.id ?? 'a1',
+    displayName: partial.displayName ?? 'Main Smurf',
+    username: partial.username ?? 'mainsmurf',
+    password: partial.password ?? 'pw',
+    networkId: partial.networkId ?? 'riot',
+    tags: partial.tags ?? [],
+    notes: partial.notes ?? '',
+    createdAt: new Date('2025-01-01').toISOString(),
+    updatedAt: new Date('2025-01-01').toISOString(),
+    riotId: partial.riotId ?? '',
+    region: partial.region ?? 'na1',
+    games: partial.games ?? ['lol'],
+    cachedRanks: partial.cachedRanks ?? [],
+    ...partial,
+  }
+}
+
+describe('AccountList — onboarding', () => {
+  beforeEach(() => {
+    setSelectedNetwork.mockReset()
+    setSelectedTag.mockReset()
+    setSearchQuery.mockReset()
+    removeAccount.mockReset()
+    addAccount.mockReset()
+  })
+
+  it('auto-opens the Add Account wizard when no accounts exist', () => {
+    render_withOverrides({ accounts: [], filteredAccounts: [] })
+
+    // The wizard's step-1 subtitle is a reliable marker that it mounted.
+    expect(screen.getByText(/Start with your sign-in credentials/i)).toBeInTheDocument()
+  })
+
+  it('does not open the wizard while the recovery-phrase modal is up', () => {
+    render_withOverrides({
+      accounts: [],
+      filteredAccounts: [],
+      showRecoveryPhraseModal: true,
+    })
+
+    expect(screen.queryByText(/Start with your sign-in credentials/i)).not.toBeInTheDocument()
+  })
+
+  it('does not auto-open the wizard for users who already have accounts', () => {
+    const acc = makeAccount()
+    render_withOverrides({ accounts: [acc], filteredAccounts: [acc] })
+
+    expect(screen.queryByText(/Start with your sign-in credentials/i)).not.toBeInTheDocument()
+  })
+})
+
+describe('AccountList — filters', () => {
+  beforeEach(() => {
+    setSelectedNetwork.mockReset()
+    setSelectedTag.mockReset()
+    setSearchQuery.mockReset()
+  })
+
+  it('fires setSelectedNetwork when user picks a network from the dropdown', async () => {
+    const user = userEvent.setup()
+    render_withOverrides({
+      accounts: [makeAccount()],
+      filteredAccounts: [makeAccount()],
+    })
+
+    const networkSelect = screen.getAllByRole('combobox')[0] // first select is Network
+    await user.selectOptions(networkSelect, 'riot')
+
+    expect(setSelectedNetwork).toHaveBeenCalledWith('riot')
+  })
+
+  it('fires setSearchQuery as user types in the search box', async () => {
+    const user = userEvent.setup()
+    render_withOverrides({
+      accounts: [makeAccount()],
+      filteredAccounts: [makeAccount()],
+    })
+
+    const search = screen.getByPlaceholderText('Search')
+    await user.type(search, 'a')
+
+    // setSearchQuery fires per keystroke; assert at least one call with the
+    // character the user typed.
+    expect(setSearchQuery).toHaveBeenCalledWith('a')
+  })
+})
+
+describe('AccountList — delete flow', () => {
+  it('opens the delete modal when the trash icon is clicked', async () => {
+    const user = userEvent.setup()
+    const acc = makeAccount({ displayName: 'Doomed Account' })
+    render_withOverrides({ accounts: [acc], filteredAccounts: [acc] })
+
+    await user.click(screen.getByRole('button', { name: /delete account/i }))
+
+    // Copy that only appears inside the confirmation modal.
+    expect(screen.getByText(/permanently delete/i)).toBeInTheDocument()
+    expect(screen.getByText(/Delete account\?/i)).toBeInTheDocument()
+  })
+
+  it('calls removeAccount when the delete is confirmed', async () => {
+    const user = userEvent.setup()
+    const acc = makeAccount({ id: 'kill-me', displayName: 'Doomed Account' })
+    removeAccount.mockResolvedValue(true)
+    render_withOverrides({ accounts: [acc], filteredAccounts: [acc] })
+
+    await user.click(screen.getByRole('button', { name: /delete account/i }))
+
+    // The modal's confirm button's accessible name is exactly "Delete"; the
+    // card's trash icon is "Delete account", so a strict match disambiguates.
+    const confirm = screen.getByRole('button', { name: /^delete$/i })
+    await user.click(confirm)
+
+    expect(removeAccount).toHaveBeenCalledWith('kill-me')
+  })
+})
+
+describe('AccountList — sound mute toggle', () => {
+  it('switches icon + aria-label when toggled', async () => {
+    const user = userEvent.setup()
+    const acc = makeAccount()
+    render_withOverrides({ accounts: [acc], filteredAccounts: [acc] })
+
+    const toggle = screen.getByRole('button', { name: /mute sounds/i })
+    await user.click(toggle)
+
+    // After click, the label should flip to "Enable sounds"
+    expect(screen.getByRole('button', { name: /enable sounds/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/__tests__/AddAccountWizard.test.tsx
+++ b/frontend/src/components/__tests__/AddAccountWizard.test.tsx
@@ -203,4 +203,106 @@ describe('AddAccountWizard', () => {
     expect(screen.getByPlaceholderText('Enter username')).toHaveValue('smurf1')
     expect(screen.getByPlaceholderText('Enter password')).toHaveValue('pw')
   })
+
+  it('shows a Custom tile on the network step as an escape hatch', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    expect(screen.getByRole('button', { name: /custom/i })).toBeInTheDocument()
+  })
+
+  it('still shows Custom when no networks match the query', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Type a nonsense query that matches no real network
+    await user.type(screen.getByLabelText(/search networks/i), 'zzzzfortnite')
+
+    expect(screen.queryByRole('button', { name: /riot games/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /steam/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /custom/i })).toBeInTheDocument()
+  })
+
+  it('requires a network name before submitting a Custom account', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    // Step 1
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Step 2 — pick Custom
+    await user.click(screen.getByRole('button', { name: /custom/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Step 3 — Add Account should be disabled until network name is entered
+    const submit = screen.getByRole('button', { name: /add account/i })
+    expect(submit).toBeDisabled()
+
+    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Steam')
+    expect(submit).toBeEnabled()
+  })
+
+  it('submits a Custom account with customNetwork + customGame and no riot/games fields', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<AddAccountWizard onClose={onClose} />)
+
+    // Step 1
+    await user.type(screen.getByPlaceholderText('Enter username'), 'cs-main')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'hunter2')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Step 2 — Custom
+    await user.click(screen.getByRole('button', { name: /custom/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Step 3 — custom inputs
+    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Steam')
+    await user.type(screen.getByPlaceholderText(/cs2, apex legends/i), 'Counter-Strike 2')
+    await user.click(screen.getByRole('button', { name: /add account/i }))
+
+    expect(addAccount).toHaveBeenCalledTimes(1)
+    const payload = addAccount.mock.calls[0][0]
+    expect(payload.networkId).toBe('custom')
+    expect(payload.customNetwork).toBe('Steam')
+    expect(payload.customGame).toBe('Counter-Strike 2')
+    expect(payload.games).toEqual([])
+    expect(payload.riotId).toBe('')
+    expect(payload.region).toBe('')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('clears custom fields when switching back from Custom to a real network', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Pick Custom, fill the name, then switch to Riot
+    await user.click(screen.getByRole('button', { name: /custom/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Steam')
+    await user.click(screen.getByRole('button', { name: /back/i }))
+    await user.click(screen.getByRole('button', { name: /riot games/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+    await user.click(screen.getByRole('button', { name: /add account/i }))
+
+    const payload = addAccount.mock.calls[0][0]
+    expect(payload.networkId).toBe('riot')
+    expect(payload.customNetwork).toBe('')
+    expect(payload.customGame).toBe('')
+    expect(payload.games).toEqual(['lol', 'tft', 'valorant'])
+  })
 })

--- a/frontend/src/components/__tests__/RecoveryPhraseModal.test.tsx
+++ b/frontend/src/components/__tests__/RecoveryPhraseModal.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+const dismissRecoveryPhraseModal = vi.fn()
+
+type StoreOverrides = Partial<{
+  showRecoveryPhraseModal: boolean
+  pendingRecoveryPhrase: string | null
+  requiresPinSetup: boolean
+}>
+
+let currentOverrides: StoreOverrides = {}
+
+vi.mock('../../stores/appStore', () => ({
+  useAppStore: () => ({
+    showRecoveryPhraseModal: currentOverrides.showRecoveryPhraseModal ?? true,
+    // Check "has own property" so an explicit `pendingRecoveryPhrase: null`
+    // passes through rather than falling back to the default string.
+    pendingRecoveryPhrase: Object.prototype.hasOwnProperty.call(
+      currentOverrides,
+      'pendingRecoveryPhrase',
+    )
+      ? currentOverrides.pendingRecoveryPhrase
+      : 'alpha beta gamma delta epsilon zeta',
+    requiresPinSetup: currentOverrides.requiresPinSetup ?? true,
+    dismissRecoveryPhraseModal,
+  }),
+}))
+
+import { RecoveryPhraseModal } from '../RecoveryPhraseModal'
+
+function render_withOverrides(overrides: StoreOverrides = {}) {
+  currentOverrides = overrides
+  return render(<RecoveryPhraseModal />)
+}
+
+describe('RecoveryPhraseModal', () => {
+  beforeEach(() => {
+    dismissRecoveryPhraseModal.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing when the modal flag is off', () => {
+    const { container } = render_withOverrides({ showRecoveryPhraseModal: false })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when there is no pending phrase', () => {
+    const { container } = render_withOverrides({ pendingRecoveryPhrase: null })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('starts with the reveal CTA and no "Continue" button', () => {
+    render_withOverrides()
+
+    expect(screen.getByRole('button', { name: /click to reveal pin/i })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /saved my recovery pin/i })).not.toBeInTheDocument()
+    // The individual phrase words should not be visible yet — the reveal UI
+    // shows dots placeholder.
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument()
+  })
+
+  it('reveals the six phrase words after the shimmer timer elapses', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render_withOverrides()
+
+    await user.click(screen.getByRole('button', { name: /click to reveal pin/i }))
+
+    // Shimmer is 1 second then setShowPhrase(true)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100)
+    })
+
+    expect(screen.getByText('alpha')).toBeInTheDocument()
+    expect(screen.getByText('zeta')).toBeInTheDocument()
+    // Continue button becomes available only after reveal.
+    expect(screen.getByRole('button', { name: /saved my recovery pin/i })).toBeInTheDocument()
+  })
+
+  it('calls dismissRecoveryPhraseModal when the user confirms saved', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render_withOverrides()
+
+    await user.click(screen.getByRole('button', { name: /click to reveal pin/i }))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100)
+    })
+
+    await user.click(screen.getByRole('button', { name: /saved my recovery pin/i }))
+
+    expect(dismissRecoveryPhraseModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('copies the phrase to clipboard when the copy button is clicked post-reveal', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+    // navigator.clipboard is a read-only accessor — defineProperty lets us
+    // swap in a spy that the component can call normally.
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    })
+
+    render_withOverrides()
+
+    await user.click(screen.getByRole('button', { name: /click to reveal pin/i }))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1100)
+    })
+
+    await user.click(screen.getByRole('button', { name: /^copy$/i }))
+
+    expect(writeText).toHaveBeenCalledWith('alpha beta gamma delta epsilon zeta')
+  })
+})

--- a/frontend/src/components/__tests__/UnlockScreen.test.tsx
+++ b/frontend/src/components/__tests__/UnlockScreen.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// All store methods mocked — we only care that UnlockScreen calls the right
+// store action with the right args for each user flow.
+
+const createVault = vi.fn()
+const unlock = vi.fn()
+const resetPasswordWithRecoveryPhrase = vi.fn()
+const clearError = vi.fn()
+
+type Overrides = Partial<{
+  appState: 'locked' | 'create' | 'unlocked' | 'loading'
+  storedUsername: string
+  passwordHint: string
+  hasRecoveryPhrase: boolean
+  error: string | null
+}>
+
+let current: Overrides = {}
+
+vi.mock('../../stores/appStore', () => ({
+  useAppStore: () => ({
+    appState: current.appState ?? 'locked',
+    storedUsername: current.storedUsername ?? '',
+    passwordHint: current.passwordHint ?? '',
+    hasRecoveryPhrase: current.hasRecoveryPhrase ?? true,
+    createVault,
+    unlock,
+    resetPasswordWithRecoveryPhrase,
+    error: current.error ?? null,
+    clearError,
+  }),
+}))
+
+// The recovery-phrase modal is not under test here and uses its own store hook.
+vi.mock('../RecoveryPhraseModal', () => ({ RecoveryPhraseModal: () => null }))
+
+import { UnlockScreen } from '../UnlockScreen'
+
+function render_withOverrides(overrides: Overrides = {}) {
+  current = overrides
+  return render(<UnlockScreen />)
+}
+
+describe('UnlockScreen — sign-in (locked state)', () => {
+  beforeEach(() => {
+    createVault.mockReset()
+    unlock.mockReset()
+    resetPasswordWithRecoveryPhrase.mockReset()
+    clearError.mockReset()
+  })
+
+  it('calls unlock() with the entered credentials', async () => {
+    const user = userEvent.setup()
+    unlock.mockResolvedValue(true)
+    render_withOverrides({ appState: 'locked' })
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'eren')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'hunter22')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    expect(unlock).toHaveBeenCalledWith('eren', 'hunter22')
+  })
+
+  it('pre-fills the username from storedUsername', () => {
+    render_withOverrides({ appState: 'locked', storedUsername: 'returning-user' })
+
+    expect(screen.getByPlaceholderText('Enter username')).toHaveValue('returning-user')
+  })
+
+  it('toggles password visibility when eye icon is clicked', async () => {
+    const user = userEvent.setup()
+    render_withOverrides({ appState: 'locked' })
+
+    const pw = screen.getByPlaceholderText('Enter password') as HTMLInputElement
+    expect(pw.type).toBe('password')
+
+    // The eye/eye-off button is the only button adjacent to the password input
+    // that isn't Sign In. Find it by its position in the DOM (no aria-label
+    // in the source, so target via its icon parent).
+    const toggle = pw.parentElement!.querySelector('button[type="button"]') as HTMLButtonElement
+    await user.click(toggle)
+
+    expect(pw.type).toBe('text')
+  })
+
+  it('does not call unlock when the username is shorter than 3 chars', async () => {
+    const user = userEvent.setup()
+    render_withOverrides({ appState: 'locked' })
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'ab')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'hunter22')
+    await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+    expect(unlock).not.toHaveBeenCalled()
+  })
+})
+
+describe('UnlockScreen — create-vault state', () => {
+  beforeEach(() => {
+    createVault.mockReset()
+  })
+
+  it('submit button reads "Create Account" when appState is create', () => {
+    render_withOverrides({ appState: 'create' })
+    expect(screen.getByRole('button', { name: /create account/i })).toBeInTheDocument()
+  })
+
+  it('blocks submit when passwords do not match', async () => {
+    const user = userEvent.setup()
+    render_withOverrides({ appState: 'create' })
+
+    await user.type(screen.getByPlaceholderText('Enter username'), 'brand-new')
+    await user.type(screen.getByPlaceholderText('Enter password'), 'hunter22')
+    // The confirm password field exists in create mode — match it by placeholder.
+    const confirm = screen.getByPlaceholderText(/confirm/i)
+    await user.type(confirm, 'mismatch22')
+
+    await user.click(screen.getByRole('button', { name: /create account/i }))
+
+    expect(createVault).not.toHaveBeenCalled()
+  })
+})
+
+describe('UnlockScreen — recovery mode', () => {
+  beforeEach(() => {
+    resetPasswordWithRecoveryPhrase.mockReset()
+  })
+
+  it('toggles into recovery mode when the "Use recovery PIN" link is clicked', async () => {
+    const user = userEvent.setup()
+    render_withOverrides({ appState: 'locked', hasRecoveryPhrase: true })
+
+    // The recovery link copy lives inline — assert it's present before clicking.
+    const link = screen.getByText(/forgot password\? use recovery pin/i)
+    await user.click(link)
+
+    expect(screen.getByText(/enter your 6-word recovery phrase/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,130 @@
+import { forwardRef } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { cn } from '../../lib/utils'
+import { MOTION_BASE, MOTION_FOCUS } from '../../lib/motion'
+import { playTick, playError, playPop } from '../../lib/sound'
+
+// Shared button primitive. All app buttons route through here so the tactile
+// language (hover lift, press, sound, focus ring) lives in one place.
+
+type Variant = 'primary' | 'secondary' | 'ghost' | 'destructive'
+type Size = 'sm' | 'md' | 'lg'
+// Click sound vocabulary — callers pick intent, the primitive picks the tone.
+//   tick  — default small commit (most buttons)
+//   pop   — satisfying commit (add-something, select-a-tile)
+//   error — destructive / cancel
+//   none  — caller is playing its own sound in the onClick handler
+type ClickSound = 'tick' | 'pop' | 'error' | 'none'
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant
+  size?: Size
+  leadingIcon?: ReactNode
+  trailingIcon?: ReactNode
+  fullWidth?: boolean
+  // Deprecated shortcut for `clickSound="none"` + silenced hover — still
+  // honoured for existing callers that just want the whole button quiet.
+  sound?: boolean
+  // Optional override for the click sound. When omitted, picks a sensible
+  // default from variant (destructive→error, otherwise tick).
+  clickSound?: ClickSound
+}
+
+const VARIANT_CLASSES: Record<Variant, string> = {
+  primary: cn(
+    'bg-[var(--color-primary)] text-white',
+    'hover:bg-[var(--color-primary)]/90',
+    'shadow-md shadow-[var(--color-primary)]/25',
+    'hover:shadow-lg hover:shadow-[var(--color-primary)]/40',
+    'disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none',
+  ),
+  secondary: cn(
+    'bg-[var(--color-muted)] text-[var(--color-foreground)]',
+    'hover:bg-[var(--color-border)]',
+    'border border-[var(--color-border)]/50',
+    'hover:border-[var(--color-border)]',
+    'disabled:opacity-50 disabled:cursor-not-allowed',
+  ),
+  ghost: cn(
+    'bg-transparent text-[var(--color-muted-foreground)]',
+    'hover:bg-[var(--color-muted)]/50 hover:text-[var(--color-foreground)]',
+    'disabled:opacity-50 disabled:cursor-not-allowed',
+  ),
+  destructive: cn(
+    'bg-red-500/90 text-white',
+    'hover:bg-red-500',
+    'shadow-md shadow-red-500/25 hover:shadow-lg hover:shadow-red-500/40',
+    'disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none',
+  ),
+}
+
+const SIZE_CLASSES: Record<Size, string> = {
+  sm: 'h-8 px-3 text-xs rounded-lg gap-1.5',
+  md: 'h-10 px-4 text-sm rounded-xl gap-2',
+  lg: 'h-11 px-5 text-sm rounded-xl gap-2',
+}
+
+export const Button = forwardRef<HTMLButtonElement, Props>(function Button(
+  {
+    variant = 'primary',
+    size = 'md',
+    leadingIcon,
+    trailingIcon,
+    fullWidth,
+    sound = true,
+    clickSound,
+    className,
+    onClick,
+    onMouseEnter,
+    disabled,
+    children,
+    ...rest
+  },
+  ref,
+) {
+  const effectiveClickSound: ClickSound =
+    clickSound ?? (sound ? (variant === 'destructive' ? 'error' : 'tick') : 'none')
+
+  return (
+    <button
+      ref={ref}
+      disabled={disabled}
+      onMouseEnter={onMouseEnter}
+      onClick={(e) => {
+        if (!disabled) {
+          switch (effectiveClickSound) {
+            case 'tick':
+              playTick()
+              break
+            case 'pop':
+              playPop()
+              break
+            case 'error':
+              playError()
+              break
+            case 'none':
+              break
+          }
+        }
+        onClick?.(e)
+      }}
+      className={cn(
+        'inline-flex items-center justify-center font-medium select-none',
+        MOTION_BASE,
+        MOTION_FOCUS,
+        // Lift + press — neutralized for disabled state via :not()
+        'enabled:hover:-translate-y-0.5 enabled:active:translate-y-0 enabled:active:scale-[0.98]',
+        'motion-reduce:enabled:hover:translate-y-0 motion-reduce:enabled:active:scale-100',
+        VARIANT_CLASSES[variant],
+        SIZE_CLASSES[size],
+        fullWidth && 'w-full',
+        className,
+      )}
+      {...rest}
+    >
+      {leadingIcon}
+      {children}
+      {trailingIcon}
+    </button>
+  )
+})

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,74 @@
+import { forwardRef } from 'react'
+import type { HTMLAttributes, ReactNode } from 'react'
+import { cn } from '../../lib/utils'
+import { MOTION_BASE, MOTION_FOCUS } from '../../lib/motion'
+import { playHover } from '../../lib/sound'
+
+// Elevated surface. The three-tier elevation language:
+//   - flat    : static content, slight border only
+//   - raised  : default — subtle shadow + top-edge highlight
+//   - elevated: for active / featured surfaces (e.g. signed-in account)
+// When `interactive` is set, the card lifts on hover, fires a hover sound,
+// and presses down on click — same vocabulary as Button/Tile.
+
+type Elevation = 'flat' | 'raised' | 'elevated'
+
+interface Props extends HTMLAttributes<HTMLDivElement> {
+  elevation?: Elevation
+  interactive?: boolean
+  active?: boolean
+  children?: ReactNode
+}
+
+const ELEVATION_CLASSES: Record<Elevation, string> = {
+  flat: 'bg-[var(--color-card)] border border-[var(--color-border)]/40',
+  raised: cn(
+    'bg-[var(--color-card)]',
+    'border border-[var(--color-border)]/50',
+    'shadow-sm',
+    // A 1px white top highlight fakes a light source from above — gives a
+    // subtle "object in a scene" feel instead of a flat sticker.
+    'before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/[0.04] before:pointer-events-none',
+  ),
+  elevated: cn(
+    'bg-[var(--color-card)]',
+    'border border-[var(--color-border)]/60',
+    'shadow-lg shadow-black/20',
+    'before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/[0.06] before:pointer-events-none',
+  ),
+}
+
+export const Card = forwardRef<HTMLDivElement, Props>(function Card(
+  { elevation = 'raised', interactive, active, className, onMouseEnter, children, ...rest },
+  ref,
+) {
+  return (
+    <div
+      ref={ref}
+      onMouseEnter={(e) => {
+        if (interactive) playHover()
+        onMouseEnter?.(e)
+      }}
+      className={cn(
+        'relative rounded-xl overflow-hidden',
+        ELEVATION_CLASSES[elevation],
+        MOTION_BASE,
+        interactive && cn(
+          MOTION_FOCUS,
+          'hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/25',
+          'hover:border-[var(--color-border)]',
+          'motion-reduce:hover:translate-y-0',
+          'cursor-default',
+        ),
+        active && cn(
+          'border-green-500/40 shadow-lg shadow-green-500/10',
+          'before:bg-green-400/20',
+        ),
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+})

--- a/frontend/src/components/ui/IconButton.tsx
+++ b/frontend/src/components/ui/IconButton.tsx
@@ -1,0 +1,82 @@
+import { forwardRef } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { cn } from '../../lib/utils'
+import { MOTION_BASE, MOTION_FOCUS } from '../../lib/motion'
+
+// Compact, icon-only button. Used for per-card actions (edit, delete, copy,
+// eye). Lighter than Button — no lift, just a subtle bg swap on hover.
+
+type Tone = 'neutral' | 'destructive' | 'success' | 'brand'
+type Size = 'sm' | 'md'
+
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: ReactNode
+  tone?: Tone
+  size?: Size
+  ariaLabel: string
+}
+
+const TONE_CLASSES: Record<Tone, string> = {
+  neutral: cn(
+    'text-[var(--color-muted-foreground)]',
+    'hover:text-[var(--color-foreground)]',
+    'hover:bg-[var(--color-muted)]/60',
+  ),
+  destructive: cn(
+    'text-[var(--color-muted-foreground)]',
+    'hover:text-red-400',
+    'hover:bg-red-500/10',
+  ),
+  success: cn(
+    'text-green-400',
+    'bg-green-500/10',
+    'hover:bg-green-500/20',
+  ),
+  brand: cn(
+    'text-[var(--color-primary)]',
+    'hover:bg-[var(--color-primary)]/10',
+  ),
+}
+
+const SIZE_CLASSES: Record<Size, string> = {
+  sm: 'w-7 h-7 rounded-md',
+  md: 'w-8 h-8 rounded-lg',
+}
+
+export const IconButton = forwardRef<HTMLButtonElement, Props>(function IconButton(
+  {
+    icon,
+    tone = 'neutral',
+    size = 'md',
+    ariaLabel,
+    className,
+    onClick,
+    onMouseEnter,
+    disabled,
+    ...rest
+  },
+  ref,
+) {
+  return (
+    <button
+      ref={ref}
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center justify-center',
+        MOTION_BASE,
+        MOTION_FOCUS,
+        'enabled:active:scale-[0.92] motion-reduce:enabled:active:scale-100',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        TONE_CLASSES[tone],
+        SIZE_CLASSES[size],
+        className,
+      )}
+      {...rest}
+    >
+      {icon}
+    </button>
+  )
+})

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,94 @@
+import { useEffect } from 'react'
+import type { ReactNode } from 'react'
+import { cn } from '../../lib/utils'
+
+// Shared modal shell. Handles:
+//   - backdrop fade-in
+//   - content scale+slide entry
+//   - Esc to dismiss
+//   - scroll lock on <body> while open
+// Consumers provide header / body / footer — we don't over-prescribe shape.
+
+interface Props {
+  onClose: () => void
+  size?: 'sm' | 'md' | 'lg'
+  dismissOnBackdrop?: boolean
+  className?: string
+  children: ReactNode
+}
+
+const SIZE_CLASSES: Record<NonNullable<Props['size']>, string> = {
+  sm: 'max-w-[95%] sm:max-w-sm',
+  md: 'max-w-[95%] sm:max-w-md',
+  lg: 'max-w-[95%] sm:max-w-lg',
+}
+
+export function Modal({ onClose, size = 'md', dismissOnBackdrop = true, className, children }: Props) {
+  // Lock body scroll while open — prevents the list behind the modal from
+  // scrolling when the user hits space/arrow keys.
+  useEffect(() => {
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = prev
+      window.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center p-3 sm:p-4 z-50 animate-fade-in"
+      onClick={dismissOnBackdrop ? onClose : undefined}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        className={cn(
+          'w-full bg-[var(--color-card)] rounded-xl sm:rounded-2xl',
+          'border border-[var(--color-border)]',
+          'shadow-2xl shadow-black/40',
+          'overflow-hidden max-h-[90vh] flex flex-col',
+          // Top-edge highlight — echoes the Card raised elevation language.
+          'relative before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-white/[0.06] before:pointer-events-none',
+          // Scale up from 96% + slide up 8px over 180ms with spring-ish easing.
+          'animate-scale-in',
+          SIZE_CLASSES[size],
+          className,
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
+// Convenience sub-shells for consistent padding/borders.
+export function ModalHeader({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={cn('p-3 sm:p-4 border-b border-[var(--color-border)]/70 shrink-0', className)}>
+      {children}
+    </div>
+  )
+}
+
+export function ModalBody({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div className={cn('p-3 sm:p-4 overflow-y-auto flex-1', className)}>{children}</div>
+  )
+}
+
+export function ModalFooter({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'p-3 sm:p-4 border-t border-[var(--color-border)]/70 shrink-0 flex gap-2 sm:gap-3',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/__tests__/Button.test.tsx
+++ b/frontend/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Button } from '../Button'
+
+// AudioContext isn't in jsdom, so Button's click-sound call harmlessly no-ops.
+// These tests focus on semantics: variant→class mapping, disabled handling,
+// event propagation.
+
+describe('Button primitive', () => {
+  it('fires onClick when clicked', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(<Button onClick={onClick}>Go</Button>)
+
+    await user.click(screen.getByRole('button', { name: /go/i }))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire onClick when disabled', async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(
+      <Button onClick={onClick} disabled>
+        Go
+      </Button>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /go/i }))
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('renders leadingIcon + trailingIcon alongside children', () => {
+    render(
+      <Button
+        leadingIcon={<span data-testid="lead">L</span>}
+        trailingIcon={<span data-testid="trail">T</span>}
+      >
+        Mid
+      </Button>,
+    )
+
+    expect(screen.getByTestId('lead')).toBeInTheDocument()
+    expect(screen.getByTestId('trail')).toBeInTheDocument()
+    expect(screen.getByRole('button')).toHaveTextContent(/LMidT/)
+  })
+
+  it('applies the destructive variant class for destructive buttons', () => {
+    render(<Button variant="destructive">Delete</Button>)
+    const btn = screen.getByRole('button', { name: /delete/i })
+    // Destructive uses a red-tinted background utility — assert by substring.
+    expect(btn.className).toMatch(/bg-red-500/)
+  })
+
+  it('stretches full-width when fullWidth prop is set', () => {
+    render(<Button fullWidth>Wide</Button>)
+    expect(screen.getByRole('button', { name: /wide/i }).className).toMatch(/w-full/)
+  })
+
+  it('uses a type="submit" button when passed type prop', () => {
+    render(<Button type="submit">Submit</Button>)
+    expect(screen.getByRole('button', { name: /submit/i })).toHaveAttribute('type', 'submit')
+  })
+})

--- a/frontend/src/components/ui/__tests__/Modal.test.tsx
+++ b/frontend/src/components/ui/__tests__/Modal.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { Modal, ModalHeader, ModalBody, ModalFooter } from '../Modal'
+
+describe('Modal primitive', () => {
+  it('calls onClose when Escape is pressed', async () => {
+    const onClose = vi.fn()
+    render(
+      <Modal onClose={onClose}>
+        <ModalBody>content</ModalBody>
+      </Modal>,
+    )
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the backdrop is clicked', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const { container } = render(
+      <Modal onClose={onClose}>
+        <ModalBody>content</ModalBody>
+      </Modal>,
+    )
+
+    // Backdrop is the outer wrapper with fixed inset — clicking it dismisses.
+    const backdrop = container.querySelector('div.fixed.inset-0') as HTMLElement
+    expect(backdrop).not.toBeNull()
+    await user.click(backdrop)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not dismiss on backdrop click when dismissOnBackdrop is false', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const { container } = render(
+      <Modal onClose={onClose} dismissOnBackdrop={false}>
+        <ModalBody>content</ModalBody>
+      </Modal>,
+    )
+
+    const backdrop = container.querySelector('div.fixed.inset-0') as HTMLElement
+    await user.click(backdrop)
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('does not dismiss when a click happens inside the modal body', async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(
+      <Modal onClose={onClose}>
+        <ModalBody>
+          <button>inner</button>
+        </ModalBody>
+      </Modal>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /inner/i }))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('locks body scroll while open and restores it on unmount', () => {
+    const prev = document.body.style.overflow
+    const { unmount } = render(
+      <Modal onClose={() => {}}>
+        <ModalBody>content</ModalBody>
+      </Modal>,
+    )
+
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe(prev)
+  })
+
+  it('renders header / body / footer content in order', () => {
+    render(
+      <Modal onClose={() => {}}>
+        <ModalHeader>
+          <h2>Title</h2>
+        </ModalHeader>
+        <ModalBody>Body text</ModalBody>
+        <ModalFooter>
+          <button>OK</button>
+        </ModalFooter>
+      </Modal>,
+    )
+
+    expect(screen.getByText('Title')).toBeInTheDocument()
+    expect(screen.getByText('Body text')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /ok/i })).toBeInTheDocument()
+  })
+})

--- a/frontend/src/lib/__tests__/sound.test.ts
+++ b/frontend/src/lib/__tests__/sound.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// The sound module reads its initial enabled/volume state from localStorage
+// when it first loads. vi.resetModules() lets each test prime localStorage
+// and then dynamically import a fresh copy so load-time behaviour is testable.
+
+const PREF_KEY = 'osm.sounds.enabled'
+const VOL_KEY = 'osm.sounds.volume.v2'
+
+async function freshSound() {
+  vi.resetModules()
+  return await import('../sound')
+}
+
+describe('sound module — persistence', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  describe('setSoundsEnabled', () => {
+    it('persists "1" when enabling', async () => {
+      const sound = await freshSound()
+      sound.setSoundsEnabled(true)
+      expect(localStorage.getItem(PREF_KEY)).toBe('1')
+      expect(sound.getSoundsEnabled()).toBe(true)
+    })
+
+    it('persists "0" when disabling', async () => {
+      const sound = await freshSound()
+      sound.setSoundsEnabled(false)
+      expect(localStorage.getItem(PREF_KEY)).toBe('0')
+      expect(sound.getSoundsEnabled()).toBe(false)
+    })
+
+    it('round-trips through a fresh module import (simulates app reload)', async () => {
+      const s1 = await freshSound()
+      s1.setSoundsEnabled(false)
+
+      const s2 = await freshSound()
+      expect(s2.getSoundsEnabled()).toBe(false)
+    })
+  })
+
+  describe('initial state', () => {
+    it('defaults to enabled when localStorage has no entry', async () => {
+      const sound = await freshSound()
+      expect(sound.getSoundsEnabled()).toBe(true)
+    })
+
+    it('respects a pre-existing "0" entry', async () => {
+      localStorage.setItem(PREF_KEY, '0')
+      const sound = await freshSound()
+      expect(sound.getSoundsEnabled()).toBe(false)
+    })
+  })
+
+  describe('setSoundsVolume', () => {
+    it('clamps values above 1 down to 1', async () => {
+      const sound = await freshSound()
+      sound.setSoundsVolume(1.5)
+      expect(localStorage.getItem(VOL_KEY)).toBe('1')
+    })
+
+    it('clamps negative values up to 0', async () => {
+      const sound = await freshSound()
+      sound.setSoundsVolume(-0.2)
+      expect(localStorage.getItem(VOL_KEY)).toBe('0')
+    })
+
+    it('persists a normal in-range value', async () => {
+      const sound = await freshSound()
+      sound.setSoundsVolume(0.35)
+      expect(localStorage.getItem(VOL_KEY)).toBe('0.35')
+    })
+
+    it('falls back to the default when the stored value is invalid', async () => {
+      localStorage.setItem(VOL_KEY, 'not-a-number')
+      const sound = await freshSound()
+      // Trigger a write so we can read back the internal volume via localStorage.
+      // The module has no volume-getter, so we round-trip via the setter.
+      // Invalid stored value should have been ignored at load → default 0.2.
+      sound.setSoundsVolume(0.2)
+      expect(localStorage.getItem(VOL_KEY)).toBe('0.2')
+    })
+  })
+})

--- a/frontend/src/lib/motion.ts
+++ b/frontend/src/lib/motion.ts
@@ -1,0 +1,32 @@
+// Shared motion vocabulary. Centralising these classes means we can tweak the
+// feel in one place and keep "the app" coherent instead of every component
+// inventing its own easing.
+//
+// Principles:
+//   - 150ms for most UI transitions (fast enough to feel instant, slow enough
+//     to register).
+//   - ease-out for entries, ease-in for exits. Things "settle" on arrival.
+//   - Hover lifts are small (1px) — the goal is acknowledgement, not theatre.
+//   - Press is small (2% scale). The pixels go down when you push them.
+//   - `motion-reduce` variants auto-neutralise everything when the user has
+//     prefers-reduced-motion set.
+
+// Base transition applied to interactive surfaces.
+export const MOTION_BASE =
+  'transition-all duration-150 ease-out motion-reduce:transition-none'
+
+// Liftable surface — small hover rise + shadow swell. Use on cards/tiles/buttons.
+export const MOTION_LIFT =
+  'hover:-translate-y-0.5 hover:shadow-lg motion-reduce:hover:translate-y-0 motion-reduce:hover:shadow-none'
+
+// Pressable — scales down slightly on click. Communicates "I got the click".
+export const MOTION_PRESS =
+  'active:scale-[0.98] motion-reduce:active:scale-100'
+
+// Combined: the default for buttons and interactive tiles.
+export const MOTION_INTERACTIVE = `${MOTION_BASE} ${MOTION_LIFT} ${MOTION_PRESS}`
+
+// Focus ring for keyboard users. Matches the primary colour, offset from the
+// surface so it's visible on dark cards.
+export const MOTION_FOCUS =
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-background)]'

--- a/frontend/src/lib/sound.ts
+++ b/frontend/src/lib/sound.ts
@@ -1,0 +1,195 @@
+// Programmatic UI sounds via the Web Audio API.
+//
+// Why not audio files? Zero asset cost, perfect control of pitch/envelope, and
+// trivial to iterate on. The "relaxing" direction here means soft attacks,
+// warm harmonics (sine + triangle body), lower pitches, and gentle decays —
+// the opposite of the sharp percussive ticks in tool-focused apps.
+//
+// Vocabulary:
+//   hover   — very quiet low tick when the cursor enters an interactive
+//             surface. Volume is ~30% of tick so continuous mousing doesn't
+//             feel noisy.
+//   tick    — small commit (toggle a tag, step a chevron).
+//   pop     — bigger commit (pick a tile, add an account).
+//   success — two-note ascending warm chime on meaningful completions.
+//   error   — deflating descending tone on cancel/failure.
+//
+// Autoplay: AudioContext starts 'suspended' until a user gesture. We resume
+// on the first play() call, which is always triggered from a user event.
+// jsdom (unit tests) has no AudioContext — the module no-ops cleanly.
+
+type AudioCtor = typeof AudioContext
+
+declare global {
+  interface Window {
+    webkitAudioContext?: AudioCtor
+  }
+}
+
+const PREF_KEY = 'osm.sounds.enabled'
+// Versioned key — bump when we change the default so users testing an
+// earlier volume aren't locked to the old (louder) value.
+const VOL_KEY = 'osm.sounds.volume.v2'
+
+let ctx: AudioContext | null = null
+let master: GainNode | null = null
+let enabled = loadEnabled()
+let volume = loadVolume()
+
+function loadEnabled(): boolean {
+  if (typeof localStorage === 'undefined') return true
+  const v = localStorage.getItem(PREF_KEY)
+  return v === null ? true : v === '1'
+}
+
+function loadVolume(): number {
+  if (typeof localStorage === 'undefined') return 0.2
+  const v = Number(localStorage.getItem(VOL_KEY))
+  return Number.isFinite(v) && v > 0 && v <= 1 ? v : 0.2
+}
+
+function ensureContext(): { ctx: AudioContext; master: GainNode } | null {
+  if (typeof window === 'undefined') return null
+  const Ctor = (window.AudioContext || window.webkitAudioContext) as AudioCtor | undefined
+  if (!Ctor) return null
+  if (!ctx) {
+    try {
+      ctx = new Ctor()
+      master = ctx.createGain()
+      master.gain.value = volume
+      master.connect(ctx.destination)
+    } catch {
+      return null
+    }
+  }
+  if (ctx.state === 'suspended') {
+    // Fire-and-forget; first play call happens inside a user gesture so this
+    // resolves immediately in practice.
+    ctx.resume().catch(() => {})
+  }
+  return { ctx: ctx!, master: master! }
+}
+
+export function setSoundsEnabled(on: boolean): void {
+  enabled = on
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(PREF_KEY, on ? '1' : '0')
+  }
+}
+
+export function getSoundsEnabled(): boolean {
+  return enabled
+}
+
+export function setSoundsVolume(v: number): void {
+  volume = Math.max(0, Math.min(1, v))
+  if (master) master.gain.value = volume
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem(VOL_KEY, String(volume))
+  }
+}
+
+// Two ±pct random multipliers — used to keep every voice slightly different.
+// Real tactile surfaces never produce identical sound twice; our ears tune
+// out repetition very quickly, which is what makes fixed synthesised clicks
+// feel "annoying" after a few interactions. ±4% on pitch is below conscious
+// pitch discrimination but enough to break the repetition.
+function jitter(value: number, pct: number): number {
+  return value * (1 + (Math.random() * 2 - 1) * pct)
+}
+
+// Low-level voice: single oscillator with soft attack + exponential decay
+// routed through a lowpass that opens briefly on attack. The filter gives the
+// "woody" warmth that straight sines lack.
+function voice(opts: {
+  freq: number
+  type?: OscillatorType
+  peak?: number
+  attackMs?: number
+  decayMs?: number
+  filterStart?: number
+  filterEnd?: number
+  delayMs?: number
+  // Set true to keep the voice deterministic (used rarely — e.g. when a
+  // caller needs a specific target pitch for a two-note chord).
+  fixed?: boolean
+}): void {
+  if (!enabled) return
+  const audio = ensureContext()
+  if (!audio) return
+  const { ctx, master } = audio
+
+  const {
+    freq,
+    type = 'sine',
+    peak = 0.35,
+    attackMs = 4,
+    decayMs = 90,
+    filterStart = 2400,
+    filterEnd = 800,
+    delayMs = 0,
+    fixed = false,
+  } = opts
+
+  // Organic variance. Pitch ±4%, loudness ±12%.
+  const effectiveFreq = fixed ? freq : jitter(freq, 0.04)
+  const effectivePeak = fixed ? peak : jitter(peak, 0.12)
+
+  const t0 = ctx.currentTime + delayMs / 1000
+  const atk = attackMs / 1000
+  const dec = decayMs / 1000
+
+  const osc = ctx.createOscillator()
+  osc.type = type
+  osc.frequency.value = effectiveFreq
+
+  const gain = ctx.createGain()
+  gain.gain.setValueAtTime(0, t0)
+  gain.gain.linearRampToValueAtTime(effectivePeak, t0 + atk)
+  // exponential can't ramp to 0, use a small epsilon
+  gain.gain.exponentialRampToValueAtTime(0.0001, t0 + atk + dec)
+
+  const filter = ctx.createBiquadFilter()
+  filter.type = 'lowpass'
+  filter.frequency.setValueAtTime(filterStart, t0)
+  filter.frequency.exponentialRampToValueAtTime(Math.max(200, filterEnd), t0 + atk + dec)
+
+  osc.connect(filter).connect(gain).connect(master)
+  osc.start(t0)
+  osc.stop(t0 + atk + dec + 0.05)
+}
+
+// Deduped hover — 120ms window so grazing across a list of cards doesn't
+// machine-gun the ear. Soft, short, felt-like — the user said the earlier
+// profile felt "annoying on repetition", so we lean toward "barely there".
+let lastHover = 0
+export function playHover(): void {
+  const now = typeof performance !== 'undefined' ? performance.now() : Date.now()
+  if (now - lastHover < 120) return
+  lastHover = now
+  voice({ freq: 280, type: 'sine', peak: 0.05, attackMs: 3, decayMs: 90, filterStart: 900, filterEnd: 380 })
+}
+
+export function playTick(): void {
+  // Warmer two-layer: a sine body with a soft triangle under-tone for weight.
+  // Peak lowered from 0.22 to ~0.15 so repeated clicks don't fatigue.
+  voice({ freq: 620, type: 'sine', peak: 0.15, attackMs: 3, decayMs: 85, filterStart: 1900, filterEnd: 700 })
+  voice({ freq: 310, type: 'triangle', peak: 0.1, attackMs: 4, decayMs: 100, filterStart: 1100, filterEnd: 400 })
+}
+
+// Layered: high blip for articulation + low triangle body for "satisfaction".
+export function playPop(): void {
+  voice({ freq: 820, type: 'sine', peak: 0.18, attackMs: 4, decayMs: 80, filterStart: 2400, filterEnd: 950 })
+  voice({ freq: 210, type: 'triangle', peak: 0.26, attackMs: 6, decayMs: 160, filterStart: 1300, filterEnd: 380 })
+}
+
+export function playSuccess(): void {
+  // Fixed pitches so the interval (perfect fifth) stays musical.
+  voice({ freq: 523.25, type: 'sine', peak: 0.22, attackMs: 8, decayMs: 200, filterStart: 2200, filterEnd: 750, fixed: true }) // C5
+  voice({ freq: 784, type: 'sine', peak: 0.22, attackMs: 8, decayMs: 240, filterStart: 2200, filterEnd: 850, delayMs: 100, fixed: true }) // G5
+}
+
+export function playError(): void {
+  voice({ freq: 420, type: 'sine', peak: 0.18, attackMs: 6, decayMs: 140, filterStart: 1600, filterEnd: 520 })
+  voice({ freq: 315, type: 'sine', peak: 0.18, attackMs: 6, decayMs: 180, filterStart: 1300, filterEnd: 450, delayMs: 80 })
+}

--- a/frontend/src/lib/telemetry.ts
+++ b/frontend/src/lib/telemetry.ts
@@ -1,0 +1,41 @@
+// Telemetry wrapper for the frontend. Emits events through the Wails
+// LogEvent binding, which forwards them to the Go-side logger.
+//
+// The typed `track` helpers below act as the **whitelist** of fields that
+// ever leave React. Anything not in this file should not be logged — in
+// particular: passwords, usernames, Riot IDs, account IDs, display names,
+// or tag names. Coarse counts and category IDs only.
+
+import { LogEvent } from '../../wailsjs/go/main/App'
+
+type Level = 'info' | 'warn' | 'error'
+
+// Fire-and-forget. Telemetry failures must never surface to the user.
+function emit(level: Level, event: string, attrs: Record<string, string> = {}): void {
+  try {
+    void LogEvent(level, event, attrs)
+  } catch {
+    // intentionally empty — no UI impact on telemetry failures
+  }
+}
+
+export const track = {
+  // UI events (the backend already records vault.unlock / account.add /
+  // etc. on its own — these are strictly *UI-originated* signals that the
+  // Go side can't observe, e.g. which step of the wizard the user stops
+  // at, or which filter chip they click).
+  wizardStep: (step: 'identity' | 'network' | 'details') =>
+    emit('info', 'ui.wizard_step', { step }),
+
+  wizardCancelled: (step: 'identity' | 'network' | 'details') =>
+    emit('info', 'ui.wizard_cancel', { step }),
+
+  networkFilterChange: (networkId: string) =>
+    emit('info', 'ui.filter_network', { network_id: networkId }),
+
+  gameFilterChange: (gameId: string) =>
+    emit('info', 'ui.filter_game', { game_id: gameId }),
+
+  error: (where: string, code: string) =>
+    emit('error', 'ui.error', { where, code }),
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -31,4 +31,7 @@ export interface AccountInput {
   cachedRanks?: models.CachedRank[]
   topMasteries?: models.ChampionMastery[]
   puuid?: string
+  // Custom network fields (networkId === 'custom')
+  customNetwork?: string
+  customGame?: string
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -71,3 +71,46 @@ body {
 .scrollbar-none::-webkit-scrollbar {
   display: none;
 }
+
+/*
+ * Motion vocabulary.
+ * Three shared keyframes used by modals, selection badges, and any other
+ * element that appears in response to a user action. Kept in CSS so we don't
+ * need the tailwindcss-animate plugin.
+ */
+
+@keyframes osm-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+@keyframes osm-scale-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.96); }
+  to   { opacity: 1; transform: translateY(0)   scale(1);    }
+}
+
+@keyframes osm-pop-in {
+  0%   { opacity: 0; transform: scale(0.5); }
+  60%  { opacity: 1; transform: scale(1.08); }
+  100% { transform: scale(1); }
+}
+
+.animate-fade-in {
+  animation: osm-fade-in 150ms ease-out both;
+}
+
+.animate-scale-in {
+  animation: osm-scale-in 180ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.animate-pop-in {
+  animation: osm-pop-in 240ms cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-fade-in,
+  .animate-scale-in,
+  .animate-pop-in {
+    animation: none;
+  }
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -72,6 +72,12 @@ type Account struct {
 	// Game filters - which games this account is used for
 	Games []string `json:"games,omitempty"` // e.g., ["lol", "tft", "valorant"]
 
+	// Custom network fields - populated when NetworkID == "custom" so users
+	// can label platforms we don't have first-class support for (Steam, Epic,
+	// Battle.net, etc.) without needing a code change.
+	CustomNetwork string `json:"customNetwork,omitempty"` // e.g., "Steam"
+	CustomGame    string `json:"customGame,omitempty"`    // e.g., "Counter-Strike 2"
+
 	// Cached rank data (persists even when not signed in)
 	CachedRanks []CachedRank `json:"cachedRanks,omitempty"`
 

--- a/internal/telemetry/client_id.go
+++ b/internal/telemetry/client_id.go
@@ -1,0 +1,31 @@
+package telemetry
+
+import (
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// loadOrCreateClientID returns a stable anonymous identifier for this
+// install. The value is generated once, written to disk, and reused on
+// every subsequent launch — giving backends a way to compute DAU/MAU
+// without ever seeing any user data.
+//
+// path is the absolute file path (caller-supplied so it can be overridden
+// in tests).
+func loadOrCreateClientID(path string) (string, error) {
+	if data, err := os.ReadFile(path); err == nil {
+		id := strings.TrimSpace(string(data))
+		if _, perr := uuid.Parse(id); perr == nil {
+			return id, nil
+		}
+		// Fall through to regenerate on a corrupted file.
+	}
+
+	id := uuid.NewString()
+	if err := os.WriteFile(path, []byte(id+"\n"), 0600); err != nil {
+		return "", err
+	}
+	return id, nil
+}

--- a/internal/telemetry/logger.go
+++ b/internal/telemetry/logger.go
@@ -1,0 +1,319 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Options configures a Logger. Zero values fall back to defaults suitable
+// for the desktop app; tests override them to point at a scratch dir.
+type Options struct {
+	Dir         string        // directory to write logs into
+	ClientID    string        // stable anonymous ID (loaded by caller)
+	ServiceName string
+	Version     string
+	MaxSize     int64         // per-file size before rotation (bytes)
+	Backups     int           // number of rotated files to retain
+	FlushEvery  time.Duration // buffered flush cadence
+	Now         func() time.Time // overridable clock for tests
+}
+
+// Logger is the singleton event sink. All calls are safe for concurrent
+// use. Failures in the I/O path are swallowed — telemetry must never fail
+// the application.
+type Logger struct {
+	mu       sync.Mutex
+	writer   *rotatingWriter
+	resource map[string]interface{}
+	now      func() time.Time
+
+	flushDone chan struct{}
+	wg        sync.WaitGroup
+	closed    bool
+}
+
+// New constructs a Logger and starts its flush goroutine. Close must be
+// called on shutdown to flush buffered records.
+func New(opts Options) (*Logger, error) {
+	if opts.MaxSize == 0 {
+		opts.MaxSize = defaultMaxSize
+	}
+	if opts.Backups == 0 {
+		opts.Backups = defaultBackups
+	}
+	if opts.FlushEvery == 0 {
+		opts.FlushEvery = time.Duration(defaultFlushEvery) * time.Second
+	}
+	if opts.Now == nil {
+		opts.Now = func() time.Time { return time.Now().UTC() }
+	}
+	if opts.ClientID == "" {
+		opts.ClientID = uuid.NewString() // fallback so we never emit a blank ID
+	}
+
+	w, err := newRotatingWriter(opts.Dir, logFileName, opts.MaxSize, opts.Backups)
+	if err != nil {
+		return nil, err
+	}
+
+	l := &Logger{
+		writer: w,
+		now:    opts.Now,
+		resource: map[string]interface{}{
+			"service.name":    opts.ServiceName,
+			"service.version": opts.Version,
+			"os.type":         runtime.GOOS,
+			"client.id":       opts.ClientID,
+			"session.id":      uuid.NewString(),
+		},
+		flushDone: make(chan struct{}),
+	}
+
+	l.wg.Add(1)
+	go l.flushLoop(opts.FlushEvery)
+	return l, nil
+}
+
+// Log appends a record to the buffered writer. Errors are swallowed.
+// attrs may be nil; keys/values should be coarse (counts, category IDs).
+// DO NOT pass credentials, usernames, passwords, Riot IDs, or any other
+// vault data — the whitelist-by-caller invariant is load-bearing.
+func (l *Logger) Log(sev Severity, body string, attrs map[string]interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.closed {
+		return
+	}
+	rec := Record{
+		Timestamp:      l.now(),
+		SeverityText:   sev.Text(),
+		SeverityNumber: int(sev),
+		Body:           body,
+		Attributes:     attrs,
+		Resource:       l.resource,
+	}
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return
+	}
+	// Single write per record so the rotator sees per-record sizes and can
+	// rotate between records rather than in the middle of one.
+	_, _ = l.writer.Write(append(b, '\n'))
+}
+
+func (l *Logger) flushLoop(interval time.Duration) {
+	defer l.wg.Done()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			l.flush()
+		case <-l.flushDone:
+			l.flush()
+			return
+		}
+	}
+}
+
+// flush asks the OS to persist buffered pages. Writes themselves are
+// already direct — this is for durability across crashes.
+func (l *Logger) flush() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.writer != nil {
+		_ = l.writer.Sync()
+	}
+}
+
+// Close stops the flush loop, flushes any buffered records, and closes
+// the underlying file. Safe to call more than once.
+func (l *Logger) Close() error {
+	l.mu.Lock()
+	if l.closed {
+		l.mu.Unlock()
+		return nil
+	}
+	l.closed = true
+	l.mu.Unlock()
+
+	close(l.flushDone)
+	l.wg.Wait()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.writer != nil {
+		return l.writer.Close()
+	}
+	return nil
+}
+
+// ----- Package-level singleton helpers --------------------------------
+//
+// The Wails App uses these from multiple goroutines. Calls before Init
+// (or after Close) are no-ops, so unit tests and tools can skip setup.
+
+var (
+	defaultMu     sync.RWMutex
+	defaultLogger *Logger
+)
+
+// Init builds the default logger wired to the user's config directory.
+// serviceName/version are embedded in every record's resource block.
+// Returns nil on success; errors are non-fatal and the caller should log
+// and continue without telemetry.
+func Init(serviceName, version string) error {
+	dir, err := logsDir()
+	if err != nil {
+		return err
+	}
+	idPath, err := clientIDPath()
+	if err != nil {
+		return err
+	}
+	id, err := loadOrCreateClientID(idPath)
+	if err != nil {
+		return err
+	}
+
+	l, err := New(Options{
+		Dir:         dir,
+		ClientID:    id,
+		ServiceName: serviceName,
+		Version:     version,
+	})
+	if err != nil {
+		return err
+	}
+
+	defaultMu.Lock()
+	if defaultLogger != nil {
+		_ = defaultLogger.Close()
+	}
+	defaultLogger = l
+	defaultMu.Unlock()
+	return nil
+}
+
+// Log records an event on the default logger. No-op if Init failed or
+// was never called.
+func Log(sev Severity, body string, attrs map[string]interface{}) {
+	defaultMu.RLock()
+	l := defaultLogger
+	defaultMu.RUnlock()
+	if l == nil {
+		return
+	}
+	l.Log(sev, body, attrs)
+}
+
+// Close shuts down the default logger. Safe to call from shutdown paths
+// even if Init was never called.
+func Close() error {
+	defaultMu.Lock()
+	l := defaultLogger
+	defaultLogger = nil
+	defaultMu.Unlock()
+	if l == nil {
+		return nil
+	}
+	return l.Close()
+}
+
+// SetDefault replaces the singleton. Exported for tests that need to
+// install their own logger; production code should call Init.
+func SetDefault(l *Logger) {
+	defaultMu.Lock()
+	defer defaultMu.Unlock()
+	defaultLogger = l
+}
+
+// Helper that other packages in the Wails app import, so they don't need
+// to construct the attrs map inline for the common case.
+func LogInfo(body string, attrs map[string]interface{}) {
+	Log(SeverityInfo, body, attrs)
+}
+
+// Helper kept for non-fatal errors (e.g., detection failures). Body
+// should be a short machine-readable code; use attrs for context.
+func LogError(body string, attrs map[string]interface{}) {
+	Log(SeverityError, body, attrs)
+}
+
+// Read scans all log files for the current install and returns every
+// record in chronological order. Intended for debugging / support flows
+// where the user exports their local logs. Returns (nil, nil) if no
+// log file has been written yet.
+func Read() ([]Record, error) {
+	dir, err := logsDir()
+	if err != nil {
+		return nil, err
+	}
+	return readDir(dir)
+}
+
+func readDir(dir string) ([]Record, error) {
+	// Read oldest-first: .3, .2, .1, active
+	paths := []string{}
+	for i := defaultBackups; i >= 1; i-- {
+		p := dir + string(os.PathSeparator) + logFileName + "." + itoa(i)
+		if _, err := os.Stat(p); err == nil {
+			paths = append(paths, p)
+		}
+	}
+	active := dir + string(os.PathSeparator) + logFileName
+	if _, err := os.Stat(active); err == nil {
+		paths = append(paths, active)
+	}
+
+	var out []Record
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		for _, line := range splitLines(data) {
+			if len(line) == 0 {
+				continue
+			}
+			var r Record
+			if err := json.Unmarshal(line, &r); err != nil {
+				continue
+			}
+			out = append(out, r)
+		}
+	}
+	return out, nil
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
+func splitLines(data []byte) [][]byte {
+	var lines [][]byte
+	start := 0
+	for i, b := range data {
+		if b == '\n' {
+			lines = append(lines, data[start:i])
+			start = i + 1
+		}
+	}
+	if start < len(data) {
+		lines = append(lines, data[start:])
+	}
+	return lines
+}

--- a/internal/telemetry/logger_test.go
+++ b/internal/telemetry/logger_test.go
@@ -1,0 +1,192 @@
+package telemetry
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func newTestLogger(t *testing.T, maxSize int64, backups int) (*Logger, string) {
+	t.Helper()
+	dir := t.TempDir()
+	l, err := New(Options{
+		Dir:         dir,
+		ClientID:    "test-client",
+		ServiceName: "test",
+		Version:     "0.0.0-test",
+		MaxSize:     maxSize,
+		Backups:     backups,
+		FlushEvery:  50 * time.Millisecond,
+		Now:         func() time.Time { return time.Unix(0, 0).UTC() },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return l, dir
+}
+
+func TestLogger_WritesOTelRecord(t *testing.T) {
+	l, dir := newTestLogger(t, 1<<20, 3)
+	l.Log(SeverityInfo, "app.start", map[string]interface{}{"latency_ms": 42})
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, logFileName))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	var r Record
+	line := strings.TrimRight(string(data), "\n")
+	if err := json.Unmarshal([]byte(line), &r); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if r.Body != "app.start" {
+		t.Errorf("body = %q, want app.start", r.Body)
+	}
+	if r.SeverityText != "INFO" || r.SeverityNumber != int(SeverityInfo) {
+		t.Errorf("severity = (%s, %d), want (INFO, %d)", r.SeverityText, r.SeverityNumber, SeverityInfo)
+	}
+	if r.Attributes["latency_ms"].(float64) != 42 {
+		t.Errorf("latency_ms = %v, want 42", r.Attributes["latency_ms"])
+	}
+	for _, k := range []string{"service.name", "service.version", "os.type", "client.id", "session.id"} {
+		if _, ok := r.Resource[k]; !ok {
+			t.Errorf("resource missing %q", k)
+		}
+	}
+	if r.Resource["client.id"] != "test-client" {
+		t.Errorf("client.id = %v, want test-client", r.Resource["client.id"])
+	}
+}
+
+func TestLogger_RotatesWhenMaxSizeExceeded(t *testing.T) {
+	// Keep maxSize small enough that every second record triggers rotation.
+	l, dir := newTestLogger(t, 200, 2)
+
+	for i := 0; i < 10; i++ {
+		l.Log(SeverityInfo, "noise", map[string]interface{}{"i": i, "pad": strings.Repeat("x", 80)})
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+
+	names := map[string]bool{}
+	for _, e := range entries {
+		names[e.Name()] = true
+	}
+	if !names[logFileName] {
+		t.Errorf("expected active %s in %v", logFileName, names)
+	}
+	// At least one rotated file should have been produced.
+	if !names[logFileName+".1"] {
+		t.Errorf("expected at least one rotated backup in %v", names)
+	}
+	// Never retain more than backups+1 files total.
+	if len(names) > 3 {
+		t.Errorf("expected ≤3 log files, got %d: %v", len(names), names)
+	}
+}
+
+func TestLogger_ConcurrentCallersDoNotCorruptLines(t *testing.T) {
+	l, dir := newTestLogger(t, 1<<20, 3)
+
+	done := make(chan struct{})
+	for g := 0; g < 4; g++ {
+		go func(id int) {
+			for i := 0; i < 50; i++ {
+				l.Log(SeverityInfo, "concurrent", map[string]interface{}{"goroutine": id, "i": i})
+			}
+			done <- struct{}{}
+		}(g)
+	}
+	for i := 0; i < 4; i++ {
+		<-done
+	}
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	f, err := os.Open(filepath.Join(dir, logFileName))
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	count := 0
+	for scanner.Scan() {
+		var r Record
+		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			t.Fatalf("line %d not valid JSON: %v (%q)", count, err, scanner.Text())
+		}
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if count != 4*50 {
+		t.Errorf("wrote %d records, want %d", count, 4*50)
+	}
+}
+
+func TestLogger_LogAfterCloseIsNoOp(t *testing.T) {
+	l, dir := newTestLogger(t, 1<<20, 3)
+	if err := l.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	l.Log(SeverityInfo, "after-close", nil) // must not panic
+
+	data, _ := os.ReadFile(filepath.Join(dir, logFileName))
+	if strings.Contains(string(data), "after-close") {
+		t.Errorf("record written after Close()")
+	}
+}
+
+func TestLoadOrCreateClientID_ReusesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "client.id")
+
+	id1, err := loadOrCreateClientID(path)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	if id1 == "" {
+		t.Fatal("empty id")
+	}
+
+	id2, err := loadOrCreateClientID(path)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if id1 != id2 {
+		t.Errorf("id regenerated: %q -> %q", id1, id2)
+	}
+}
+
+func TestLoadOrCreateClientID_RegeneratesOnCorruption(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "client.id")
+	if err := os.WriteFile(path, []byte("not-a-uuid"), 0600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	id, err := loadOrCreateClientID(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if id == "not-a-uuid" {
+		t.Error("did not regenerate on corrupted file")
+	}
+}

--- a/internal/telemetry/paths.go
+++ b/internal/telemetry/paths.go
@@ -1,0 +1,46 @@
+package telemetry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const (
+	appDirName      = "OpenSmurfManager"
+	logsDirName     = "logs"
+	logFileName     = "app.log"
+	clientIDFile    = "client.id"
+	defaultMaxSize  = 1 * 1024 * 1024 // 1 MB per file
+	defaultBackups  = 3               // keep .1, .2, .3 → 4 files total (~4 MB cap)
+	defaultFlushEvery = 5             // seconds
+)
+
+// logsDir returns the directory where rotated log files live.
+// Matches the vault location convention (os.UserConfigDir/OpenSmurfManager).
+func logsDir() (string, error) {
+	config, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("telemetry: user config dir: %w", err)
+	}
+	dir := filepath.Join(config, appDirName, logsDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("telemetry: mkdir logs: %w", err)
+	}
+	return dir, nil
+}
+
+// clientIDPath returns the path to the anonymous client ID file.
+// Stored next to the vault, outside the encrypted blob so it's available
+// before unlock (needed to emit pre-unlock events like app.start).
+func clientIDPath() (string, error) {
+	config, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("telemetry: user config dir: %w", err)
+	}
+	dir := filepath.Join(config, appDirName)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return "", fmt.Errorf("telemetry: mkdir app: %w", err)
+	}
+	return filepath.Join(dir, clientIDFile), nil
+}

--- a/internal/telemetry/record.go
+++ b/internal/telemetry/record.go
@@ -1,0 +1,47 @@
+// Package telemetry emits structured events to a local log file in
+// OpenTelemetry log-record shape. Records are JSON-lines, rotated by size
+// to bound disk usage, and safe to ship later via Filebeat / an OTLP HTTP
+// sink without changing the call sites.
+//
+// No credentials or vault data are ever passed through this package; callers
+// must only pass coarse attributes (counts, category IDs, booleans).
+package telemetry
+
+import "time"
+
+// Severity mirrors the subset of OTel severity levels we emit.
+// Numbers match the OTel spec so downstream tools index correctly.
+type Severity int
+
+const (
+	SeverityDebug Severity = 5
+	SeverityInfo  Severity = 9
+	SeverityWarn  Severity = 13
+	SeverityError Severity = 17
+)
+
+func (s Severity) Text() string {
+	switch s {
+	case SeverityDebug:
+		return "DEBUG"
+	case SeverityWarn:
+		return "WARN"
+	case SeverityError:
+		return "ERROR"
+	default:
+		return "INFO"
+	}
+}
+
+// Record is one emitted event. Field names match the OTel log record schema
+// so events drop straight into Elasticsearch / OpenSearch / Loki without
+// transformation. Attributes hold event-specific fields; Resource holds
+// session-wide fields (set once at Init).
+type Record struct {
+	Timestamp      time.Time              `json:"timestamp"`
+	SeverityText   string                 `json:"severityText"`
+	SeverityNumber int                    `json:"severityNumber"`
+	Body           string                 `json:"body"` // event name, e.g. "app.start"
+	Attributes     map[string]interface{} `json:"attributes,omitempty"`
+	Resource       map[string]interface{} `json:"resource"`
+}

--- a/internal/telemetry/rotator.go
+++ b/internal/telemetry/rotator.go
@@ -1,0 +1,112 @@
+package telemetry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// rotatingWriter writes to <dir>/<base>, rotating to <base>.1, <base>.2, ...
+// once the active file exceeds maxSize. backups is the number of historical
+// files to keep; the oldest is dropped on rotation. Not concurrency-safe on
+// its own — Logger serializes access under its mutex.
+type rotatingWriter struct {
+	dir     string
+	base    string
+	maxSize int64
+	backups int
+
+	f    *os.File
+	size int64
+}
+
+func newRotatingWriter(dir, base string, maxSize int64, backups int) (*rotatingWriter, error) {
+	w := &rotatingWriter{dir: dir, base: base, maxSize: maxSize, backups: backups}
+	if err := w.openCurrent(); err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func (w *rotatingWriter) openCurrent() error {
+	path := filepath.Join(w.dir, w.base)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("telemetry: open %s: %w", path, err)
+	}
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return fmt.Errorf("telemetry: stat %s: %w", path, err)
+	}
+	w.f = f
+	w.size = info.Size()
+	return nil
+}
+
+func (w *rotatingWriter) Write(p []byte) (int, error) {
+	if w.size+int64(len(p)) > w.maxSize && w.size > 0 {
+		if err := w.rotate(); err != nil {
+			return 0, err
+		}
+	}
+	n, err := w.f.Write(p)
+	w.size += int64(n)
+	return n, err
+}
+
+// rotate closes the current file, shifts the backup chain down by one
+// (dropping the oldest), and opens a fresh active file.
+func (w *rotatingWriter) rotate() error {
+	if err := w.f.Close(); err != nil {
+		return fmt.Errorf("telemetry: close before rotate: %w", err)
+	}
+
+	// Drop the oldest backup if we're at capacity.
+	oldest := w.backupPath(w.backups)
+	if _, err := os.Stat(oldest); err == nil {
+		if err := os.Remove(oldest); err != nil {
+			return fmt.Errorf("telemetry: drop oldest backup: %w", err)
+		}
+	}
+
+	// Shift .N-1 → .N, .N-2 → .N-1, ..., .1 → .2
+	for i := w.backups - 1; i >= 1; i-- {
+		src := w.backupPath(i)
+		dst := w.backupPath(i + 1)
+		if _, err := os.Stat(src); err == nil {
+			if err := os.Rename(src, dst); err != nil {
+				return fmt.Errorf("telemetry: shift %s: %w", src, err)
+			}
+		}
+	}
+
+	// Current → .1
+	if err := os.Rename(w.activePath(), w.backupPath(1)); err != nil {
+		return fmt.Errorf("telemetry: rotate active: %w", err)
+	}
+
+	return w.openCurrent()
+}
+
+func (w *rotatingWriter) activePath() string {
+	return filepath.Join(w.dir, w.base)
+}
+
+func (w *rotatingWriter) backupPath(n int) string {
+	return filepath.Join(w.dir, fmt.Sprintf("%s.%d", w.base, n))
+}
+
+func (w *rotatingWriter) Sync() error {
+	if w.f == nil {
+		return nil
+	}
+	return w.f.Sync()
+}
+
+func (w *rotatingWriter) Close() error {
+	if w.f == nil {
+		return nil
+	}
+	return w.f.Close()
+}

--- a/internal/telemetry/whitelist_test.go
+++ b/internal/telemetry/whitelist_test.go
@@ -1,0 +1,184 @@
+package telemetry_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Fields that must never be sent to telemetry. This list matches the deny
+// list documented in TELEMETRY.md and exists as a machine-checkable guard so
+// accidentally adding a `"username": user.Name` entry to a telemetry.Log
+// call fails the build rather than shipping user data off-device.
+var bannedAttributeKeys = map[string]struct{}{
+	"password":    {},
+	"username":    {},
+	"riotId":      {},
+	"riot_id":     {},
+	"puuid":       {},
+	"displayName": {},
+	"display_name": {},
+	"notes":       {},
+	"tags":        {},
+}
+
+// TestTelemetryAttributesAreNotVaultFields walks every Go file in the
+// repository that imports the telemetry package and inspects the AST of each
+// telemetry.Log* call. Any map-literal attribute key matching the banned list
+// fails the test.
+//
+// The test is deliberately loud about false positives — if a refactor
+// introduces a collision (e.g. a sanitized "username" that is, in fact, the
+// OS username and safe to log) the right fix is to rename the key to
+// something unambiguous like "os_user" rather than silence the check.
+func TestTelemetryAttributesAreNotVaultFields(t *testing.T) {
+	root := projectRoot(t)
+
+	var violations []string
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			// Skip vendored / generated / test-fixture dirs.
+			name := info.Name()
+			if name == "node_modules" || name == "vendor" || name == "frontend" || name == "build" ||
+				strings.HasPrefix(name, ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// Don't scan this test file — it contains the banned strings by design.
+		if strings.HasSuffix(path, "whitelist_test.go") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		node, parseErr := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		// Only scan files that actually import the telemetry package.
+		if !importsTelemetry(node) {
+			return nil
+		}
+
+		ast.Inspect(node, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			if !isTelemetryLogCall(call) {
+				return true
+			}
+			for _, arg := range call.Args {
+				cl, ok := arg.(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+				for _, elt := range cl.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					lit, ok := kv.Key.(*ast.BasicLit)
+					if !ok || lit.Kind != token.STRING {
+						continue
+					}
+					// Trim surrounding quotes.
+					key := strings.Trim(lit.Value, `"`+"`")
+					if _, banned := bannedAttributeKeys[key]; banned {
+						pos := fset.Position(lit.Pos())
+						violations = append(violations,
+							pos.Filename+":"+itoa(pos.Line)+" — banned telemetry key "+lit.Value)
+					}
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk failed: %v", err)
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("telemetry attribute allowlist violated — these keys may leak vault data:\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+func importsTelemetry(f *ast.File) bool {
+	for _, imp := range f.Imports {
+		// Path literal includes quotes.
+		if strings.Contains(imp.Path.Value, "OpenSmurfManager/internal/telemetry") {
+			return true
+		}
+	}
+	return false
+}
+
+// isTelemetryLogCall returns true for calls shaped like `telemetry.Log...(...)`.
+// Works for telemetry.Log, telemetry.LogInfo, telemetry.LogError, etc.
+func isTelemetryLogCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := sel.X.(*ast.Ident)
+	if !ok || ident.Name != "telemetry" {
+		return false
+	}
+	return strings.HasPrefix(sel.Sel.Name, "Log")
+}
+
+// projectRoot walks up from the test file's dir to find the repo root
+// (marked by go.mod). Used so the test works whether it's run from the
+// package dir or the project root.
+func projectRoot(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	dir := cwd
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.mod walking up from %s", cwd)
+		}
+		dir = parent
+	}
+}
+
+// itoa avoids pulling in strconv for this tiny use.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var digits []byte
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	if neg {
+		digits = append([]byte{'-'}, digits...)
+	}
+	return string(digits)
+}

--- a/main.go
+++ b/main.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"embed"
+	"time"
+
+	"OpenSmurfManager/internal/telemetry"
+	"OpenSmurfManager/internal/updater"
 
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
@@ -13,8 +17,21 @@ import (
 var assets embed.FS
 
 func main() {
+	// Time-zero for app-start latency. Captured as early as possible so
+	// the reported number reflects real cold-boot cost (Go init + Wails
+	// runtime + WebView2 handshake).
+	startTime := time.Now()
+
+	// Telemetry is best-effort — if it can't initialise (unwritable config
+	// dir, etc.) we log to stderr and keep running.
+	if err := telemetry.Init("OpenSmurfManager", updater.Version); err != nil {
+		println("telemetry init failed:", err.Error())
+	}
+	defer telemetry.Close()
+
 	// Create an instance of the app structure
 	app := NewApp()
+	app.startTime = startTime
 
 	// Create application with options
 	// Start with login size (vertical), will resize after unlock

--- a/main.go
+++ b/main.go
@@ -37,10 +37,11 @@ func main() {
 	// Start with login size (vertical), will resize after unlock
 	err := wails.Run(&options.App{
 		Title:     "SmurfManager",
-		Width:     380,
-		Height:    700,
-		MinWidth:  380,
-		MinHeight: 650,
+		// One size across login + main so unlocking doesn't resize the window.
+		Width:     520,
+		Height:    760,
+		MinWidth:  520,
+		MinHeight: 760,
 		MaxWidth:  700,
 		MaxHeight: 900,
 		AssetServer: &assetserver.Options{
@@ -48,6 +49,11 @@ func main() {
 		},
 		BackgroundColour: &options.RGBA{R: 15, G: 15, B: 15, A: 1}, // Match --color-background
 		OnStartup:        app.startup,
+		// Frameless: native title bar is removed; the app paints its own
+		// title bar (see WindowFrame.tsx) so chrome blends with the UI.
+		// Windows 11 still renders a rounded outline + DWM drop shadow
+		// automatically for frameless windows.
+		Frameless: true,
 		Windows: &windows.Options{
 			DisableFramelessWindowDecorations: false,
 			WebviewIsTransparent:              false,

--- a/test/e2e/custom_network_test.go
+++ b/test/e2e/custom_network_test.go
@@ -1,0 +1,210 @@
+package e2e
+
+import (
+	"os"
+	"testing"
+
+	"OpenSmurfManager/internal/accounts"
+	"OpenSmurfManager/internal/storage"
+
+	"OpenSmurfManager/internal/models"
+)
+
+// TestCustomNetwork_Roundtrip verifies that the new Custom-network fields
+// (CustomNetwork, CustomGame) survive encryption + on-disk persistence + a
+// fresh storage instance. Without this, a silent serialization regression
+// could drop the user-provided labels without any crash, leaving accounts
+// with an orphaned "custom" networkId and no label.
+func TestCustomNetwork_Roundtrip(t *testing.T) {
+	app := newTestApp(t)
+	const (
+		username = "test-user"
+		password = "correct horse battery staple"
+	)
+
+	if err := app.Storage.CreateVault(username, password); err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+
+	created, err := app.Accounts.Create(models.Account{
+		DisplayName:   "Steam Smurf",
+		Username:      "steam_user",
+		Password:      "steam_pw",
+		NetworkID:     "custom",
+		CustomNetwork: "Steam",
+		CustomGame:    "Counter-Strike 2",
+		Tags:          []string{"main"},
+		Notes:         "my CS2 account",
+	})
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("expected created account to have an ID")
+	}
+
+	// Lock + reopen from disk to prove persistence isn't just in-memory.
+	app.Storage.Lock()
+
+	store, acctSvc := reopenStorage(t, app.VaultPath)
+	if err := store.Unlock(username, password); err != nil {
+		t.Fatalf("Unlock after reopen failed: %v", err)
+	}
+
+	reloaded, err := acctSvc.GetByID(created.ID)
+	if err != nil {
+		t.Fatalf("GetByID after reopen failed: %v", err)
+	}
+
+	if reloaded.NetworkID != "custom" {
+		t.Errorf("NetworkID = %q, want %q", reloaded.NetworkID, "custom")
+	}
+	if reloaded.CustomNetwork != "Steam" {
+		t.Errorf("CustomNetwork = %q, want %q", reloaded.CustomNetwork, "Steam")
+	}
+	if reloaded.CustomGame != "Counter-Strike 2" {
+		t.Errorf("CustomGame = %q, want %q", reloaded.CustomGame, "Counter-Strike 2")
+	}
+	if reloaded.RiotID != "" {
+		t.Errorf("RiotID should be empty for custom accounts, got %q", reloaded.RiotID)
+	}
+	if len(reloaded.Games) != 0 {
+		t.Errorf("Games should be empty for custom accounts, got %v", reloaded.Games)
+	}
+}
+
+// TestCustomNetwork_CoexistsWithRiot makes sure adding a Custom account
+// alongside a Riot account doesn't scramble either — they're two discriminated
+// cases that share one Account struct, and a naive shortcut in the serializer
+// could leak fields across.
+func TestCustomNetwork_CoexistsWithRiot(t *testing.T) {
+	app := newTestApp(t)
+	const (
+		username = "test-user"
+		password = "correct horse battery staple"
+	)
+
+	if err := app.Storage.CreateVault(username, password); err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+
+	_, err := app.Accounts.Create(models.Account{
+		DisplayName: "Riot Main",
+		Username:    "rioter",
+		Password:    "pw",
+		NetworkID:   "riot",
+		RiotID:      "Player#NA1",
+		Region:      "na1",
+		Games:       []string{"lol", "tft"},
+	})
+	if err != nil {
+		t.Fatalf("Create riot account failed: %v", err)
+	}
+	_, err = app.Accounts.Create(models.Account{
+		DisplayName:   "Epic Smurf",
+		Username:      "epic_user",
+		Password:      "pw2",
+		NetworkID:     "custom",
+		CustomNetwork: "Epic Games",
+		CustomGame:    "Fortnite",
+	})
+	if err != nil {
+		t.Fatalf("Create custom account failed: %v", err)
+	}
+
+	app.Storage.Lock()
+
+	store, acctSvc := reopenStorage(t, app.VaultPath)
+	if err := store.Unlock(username, password); err != nil {
+		t.Fatalf("Unlock after reopen failed: %v", err)
+	}
+
+	all, err := acctSvc.GetAll()
+	if err != nil {
+		t.Fatalf("GetAll failed: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 accounts, got %d", len(all))
+	}
+
+	var riot, custom *models.Account
+	for i := range all {
+		switch all[i].NetworkID {
+		case "riot":
+			riot = &all[i]
+		case "custom":
+			custom = &all[i]
+		}
+	}
+	if riot == nil || custom == nil {
+		t.Fatalf("missing account: riot=%v, custom=%v", riot, custom)
+	}
+
+	// Neither account should have leaked fields from the other.
+	if riot.CustomNetwork != "" || riot.CustomGame != "" {
+		t.Errorf("Riot account has custom fields: CustomNetwork=%q CustomGame=%q",
+			riot.CustomNetwork, riot.CustomGame)
+	}
+	if custom.RiotID != "" || custom.Region != "" || len(custom.Games) > 0 {
+		t.Errorf("Custom account has Riot fields: RiotID=%q Region=%q Games=%v",
+			custom.RiotID, custom.Region, custom.Games)
+	}
+}
+
+// TestVault_TamperedFileFailsToUnlock verifies that if the encrypted payload
+// on disk has been modified after write (bit flip, partial corruption, manual
+// edit), the AES-GCM auth tag fails and the vault refuses to unlock rather
+// than silently returning garbage. This is the guarantee the whole
+// zero-knowledge model rests on.
+func TestVault_TamperedFileFailsToUnlock(t *testing.T) {
+	app := newTestApp(t)
+	const (
+		username = "test-user"
+		password = "correct horse battery staple"
+	)
+
+	if err := app.Storage.CreateVault(username, password); err != nil {
+		t.Fatalf("CreateVault failed: %v", err)
+	}
+	if _, err := app.Accounts.Create(models.Account{
+		DisplayName: "Canary",
+		Username:    "canary",
+		Password:    "pw",
+		NetworkID:   "riot",
+	}); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	app.Storage.Lock()
+
+	// Read the vault file, flip a byte somewhere inside the encrypted payload.
+	raw, err := os.ReadFile(app.VaultPath)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	if len(raw) < 200 {
+		t.Fatalf("vault file smaller than expected (%d bytes) — test assumption invalid", len(raw))
+	}
+	// Flip a byte near the end — more likely to land in the ciphertext than
+	// in the JSON header frame. GCM catches tampering anywhere in the
+	// payload, so the exact position doesn't matter much.
+	raw[len(raw)-20] ^= 0xFF
+	if err := os.WriteFile(app.VaultPath, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+
+	store, _ := reopenStorage(t, app.VaultPath)
+	err = store.Unlock(username, password)
+	if err == nil {
+		t.Fatal("tampered vault unlocked successfully — GCM auth not enforced")
+	}
+	// Keep the assertion loose; different errors can bubble up depending on
+	// where the bit flip lands (JSON decode vs AEAD authentication).
+	t.Logf("tampered vault rejected as expected: %v", err)
+}
+
+// Compile-time assertions so unused imports don't trip the build if any test
+// is ever removed from this file.
+var (
+	_ = accounts.NewAccountService
+	_ = storage.NewStorageServiceWithPath
+)


### PR DESCRIPTION
## Summary

This PR grew beyond its original telemetry scope — it now bundles four coherent changes that landed on `feat/client-telemetry`:

- **Tactile UI redesign** — shared `Button` / `IconButton` / `Card` / `Modal` primitives with consistent motion + focus-ring language; frameless window with a custom 36px title bar (Discord/VS Code-style, drag region + min/max/close); Web-Audio sound system with ±4% pitch + ±12% loudness jitter so repetition doesn't feel mechanical, scoped to card hovers + primary-button clicks; mute toggle in the main header; unified 520×760 size across lock + main so unlocking doesn't trigger a resize; auto-open Add Account wizard for zero-account users.
- **Custom network** — new `Custom` tile on the wizard's network step for platforms we don't cover natively (Steam, Epic, Battle.net, etc.). Adds `CustomNetwork` + `CustomGame` (omitempty) to `models.Account`; wizard step 3 branches to a "Network name" + optional game input; account list + filter + edit modal all render the user-provided label.
- **Client telemetry** — OTel-shaped JSON logger with rotating file writer, local-only today, capped at ~4 MB per install. A new Go AST test in `internal/telemetry/whitelist_test.go` scans every `telemetry.Log*` call site and fails the build if any attribute key matches the banned set (`password`, `username`, `riotId`, `puuid`, `displayName`, `notes`, `tags`) — closes the gap between `TELEMETRY.md` and reality.
- **Test coverage** — +42 frontend tests and +4 Go tests: sound persistence, onboarding auto-open, recovery-phrase reveal/copy, unlock + recovery flows, UI primitives, Custom-network roundtrip through encrypted storage, vault-tampering detection, telemetry whitelist enforcement. Suite went from 21 → 63 frontend tests. All green.

## Test plan
- [x] `npm test` — 63/63 frontend tests pass
- [x] `go test ./...` — all Go packages + e2e green
- [x] `tsc --noEmit` clean
- [x] `wails build -debug` — debug binary opens, frameless frame draws correctly, drag + min/max/close behave
- [ ] Manually verified on Windows 11: rounded corners + DWM drop shadow preserved for frameless window
- [ ] Manually verified: unlocking an existing vault does not resize the window
- [ ] Manually verified: first-unlock zero-account state auto-opens the wizard; dismissing it leaves the empty state intact