### PR TITLE
Rocket League support + game-first add-account wizard

### DIFF
--- a/app.go
+++ b/app.go
@@ -10,7 +10,9 @@ import (
 	"OpenSmurfManager/internal/models"
 	"OpenSmurfManager/internal/process"
 	"OpenSmurfManager/internal/providers"
+	"OpenSmurfManager/internal/providers/epic"
 	"OpenSmurfManager/internal/providers/riot"
+	"OpenSmurfManager/internal/providers/steam"
 	"OpenSmurfManager/internal/riotapi"
 	"OpenSmurfManager/internal/storage"
 	"OpenSmurfManager/internal/telemetry"
@@ -55,6 +57,8 @@ func (a *App) startup(ctx context.Context) {
 	// MustRegister call here.
 	a.providers = providers.NewRegistry()
 	a.providers.MustRegister(riot.New())
+	a.providers.MustRegister(epic.New())
+	a.providers.MustRegister(steam.New())
 
 	// App-start latency = time from main() to Wails runtime ready.
 	// Separately emit has_vault so DAU/MAU queries can distinguish

--- a/frontend/src/components/AccountList.tsx
+++ b/frontend/src/components/AccountList.tsx
@@ -9,8 +9,6 @@ import {
   Pencil,
   Trash2,
   Gamepad2,
-  RefreshCw,
-  Zap,
   ChevronUp,
   ChevronDown,
   Settings,
@@ -29,6 +27,35 @@ import { Modal, ModalBody, ModalFooter, ModalHeader } from './ui/Modal'
 import { RecoveryPhraseModal } from './RecoveryPhraseModal'
 import { SettingsModal } from './SettingsModal'
 import { AddAccountWizard } from './AddAccountWizard'
+
+// Per-game badge styling on account cards. Unknown game IDs fall back to the
+// game's name (resolved from the gameNetworks catalog) with a neutral palette,
+// so adding a new game in models.go shows up correctly without a code change
+// here. The previous hard-coded ternary defaulted to "Valorant" for any
+// unrecognized id, which mis-labelled Rocket League cards.
+const GAME_BADGE: Record<string, { label: string; classes: string }> = {
+  lol: { label: 'League', classes: 'bg-blue-500/15 text-blue-400 border border-blue-500/20' },
+  tft: { label: 'TFT', classes: 'bg-purple-500/15 text-purple-400 border border-purple-500/20' },
+  valorant: { label: 'Valorant', classes: 'bg-red-500/15 text-red-400 border border-red-500/20' },
+  rl: { label: 'Rocket League', classes: 'bg-orange-500/15 text-orange-400 border border-orange-500/20' },
+}
+
+const NEUTRAL_BADGE_CLASSES =
+  'bg-[var(--color-muted)]/40 text-[var(--color-muted-foreground)] border border-[var(--color-border)]'
+
+function gameBadge(
+  gameId: string,
+  networks: models.GameNetwork[],
+): { label: string; classes: string } {
+  const known = GAME_BADGE[gameId]
+  if (known) return known
+  for (const n of networks) {
+    for (const g of n.games) {
+      if (g.id === gameId) return { label: g.name, classes: NEUTRAL_BADGE_CLASSES }
+    }
+  }
+  return { label: gameId, classes: NEUTRAL_BADGE_CLASSES }
+}
 
 // Rank tier ordering for sorting (higher = better)
 const TIER_ORDER: Record<string, number> = {
@@ -88,7 +115,6 @@ export function AccountList() {
     selectedNetworkId,
     selectedTag,
     username,
-    isDetecting,
     detectedAccount,
     activeAccountId,
     showRecoveryPhraseModal,
@@ -96,7 +122,6 @@ export function AccountList() {
     setSelectedNetwork,
     setSelectedTag,
     removeAccount,
-    detectAndUpdateRanks,
     editAccount,
     loadAccounts,
   } = useAppStore()
@@ -239,28 +264,9 @@ export function AccountList() {
           </div>
         </div>
         <div className="flex items-center gap-1.5 sm:gap-2 shrink-0">
-          <Button
-            size="sm"
-            variant="primary"
-            onClick={async () => {
-              const matchedId = await detectAndUpdateRanks()
-              if (matchedId) {
-                // Account found and updated
-              } else if (detectedAccount) {
-                // Account detected but not in list
-              }
-            }}
-            disabled={isDetecting}
-            leadingIcon={
-              isDetecting ? (
-                <RefreshCw className="w-3.5 h-3.5 animate-spin" />
-              ) : (
-                <Zap className="w-3.5 h-3.5" />
-              )
-            }
-          >
-            <span className="hidden xs:inline">{isDetecting ? 'Detecting' : 'Detect'}</span>
-          </Button>
+          {/* Manual rank detection lives under Settings → Ranked → "Detect Ranks Now".
+              Auto-sync still runs in the background; this header used to expose a
+              redundant button that was only useful while wiring up the LCU pipeline. */}
           <IconButton
             ariaLabel={soundsOn ? 'Mute sounds' : 'Enable sounds'}
             title={soundsOn ? 'Mute sounds' : 'Enable sounds'}
@@ -579,19 +585,17 @@ export function AccountList() {
                     {/* Tags & Games */}
                     {(account.tags.length > 0 || (account.games && account.games.length > 0) || account.customGame) && (
                       <div className="flex items-center gap-2 mt-3 flex-wrap">
-                        {account.games && account.games.map(gameId => (
-                          <span
-                            key={gameId}
-                            className={cn(
-                              'px-2.5 py-1 text-xs rounded-md font-semibold',
-                              gameId === 'lol' && 'bg-blue-500/15 text-blue-400 border border-blue-500/20',
-                              gameId === 'tft' && 'bg-purple-500/15 text-purple-400 border border-purple-500/20',
-                              gameId === 'valorant' && 'bg-red-500/15 text-red-400 border border-red-500/20'
-                            )}
-                          >
-                            {gameId === 'lol' ? 'League' : gameId === 'tft' ? 'TFT' : 'Valorant'}
-                          </span>
-                        ))}
+                        {account.games && account.games.map(gameId => {
+                          const badge = gameBadge(gameId, gameNetworks)
+                          return (
+                            <span
+                              key={gameId}
+                              className={cn('px-2.5 py-1 text-xs rounded-md font-semibold', badge.classes)}
+                            >
+                              {badge.label}
+                            </span>
+                          )
+                        })}
                         {isCustomNetwork && account.customGame && (
                           <span className="px-2.5 py-1 text-xs rounded-md font-semibold bg-indigo-500/15 text-indigo-300 border border-indigo-500/20">
                             {account.customGame}
@@ -652,9 +656,15 @@ export function AccountList() {
         </div>
       </div>
 
-      {/* Add flow — progressive-disclosure wizard */}
+      {/* Add flow — progressive-disclosure wizard. Sticky during first-account
+          onboarding so a stray click on the blurred backdrop (or a stray Esc)
+          can't dump the user out of a flow they only just started. The Cancel
+          button stays as the explicit exit. */}
       {showAddModal && (
-        <AddAccountWizard onClose={() => setShowAddModal(false)} />
+        <AddAccountWizard
+          onClose={() => setShowAddModal(false)}
+          sticky={allAccounts.length === 0}
+        />
       )}
 
       {/* Edit flow — one-page form (user already knows the fields) */}

--- a/frontend/src/components/AddAccountWizard.tsx
+++ b/frontend/src/components/AddAccountWizard.tsx
@@ -10,31 +10,39 @@ import {
   Flame,
   Plus,
   Puzzle,
+  Rocket,
+  Store,
+  Gamepad,
 } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import { useAppStore } from '../stores/appStore'
 import { cn } from '../lib/utils'
+import { buildGamesCatalog, type CatalogGame } from '../lib/catalog'
 import { MOTION_BASE, MOTION_FOCUS } from '../lib/motion'
 import { Button } from './ui/Button'
-import { Modal, ModalBody, ModalFooter, ModalHeader } from './ui/Modal'
+import { Modal, ModalBody, ModalFooter } from './ui/Modal'
 import { models } from '../../wailsjs/go/models'
 
 // Progressive-disclosure add-account wizard.
 // Step 1: Identity (username, password, optional display name)
-// Step 2: Network picker (visual tiles + fuzzy search)
-// Step 3: Network-specific details (all optional — sensible defaults let users
-//         skip straight to Save)
+// Step 2: Game (pick the game first — what players actually think about)
+// Step 3: Network (only when the chosen game ships on 2+ stores, e.g. RL on
+//         Epic + Steam — multi-select. Skipped for single-store games.)
+// Step 4: Details (tags, notes, Riot ID/region for Riot games — all optional)
 
-type Step = 'identity' | 'network' | 'details'
+type Step = 'identity' | 'game' | 'network' | 'details'
 
-const STEPS: Step[] = ['identity', 'network', 'details']
-
-// Sentinel for user-defined networks we don't have first-class support for
-// (Steam, Epic, Battle.net, etc.). The user provides a label in step 3.
+// Sentinel for user-defined games we don't have first-class support for.
+// Picking "Custom" on the game step routes straight to the details step where
+// the user labels their own game + storefront.
+export const CUSTOM_GAME_ID = 'custom'
+// Backwards-compatible alias — the storage layer still stores NetworkID="custom".
 export const CUSTOM_NETWORK_ID = 'custom'
 
 const NETWORK_VISUAL: Record<string, { icon: LucideIcon; color: string }> = {
   riot: { icon: Flame, color: 'text-red-400 bg-red-500/10 border-red-500/30' },
+  epic: { icon: Store, color: 'text-fuchsia-300 bg-fuchsia-500/10 border-fuchsia-500/30' },
+  steam: { icon: Gamepad, color: 'text-sky-300 bg-sky-500/10 border-sky-500/30' },
   [CUSTOM_NETWORK_ID]: {
     icon: Puzzle,
     color: 'text-indigo-300 bg-indigo-500/10 border-indigo-500/30',
@@ -45,6 +53,11 @@ const GAME_VISUAL: Record<string, { icon: LucideIcon; color: string }> = {
   lol: { icon: Swords, color: 'text-blue-300 bg-blue-500/10 border-blue-500/30' },
   tft: { icon: Sparkles, color: 'text-purple-300 bg-purple-500/10 border-purple-500/30' },
   valorant: { icon: Crosshair, color: 'text-rose-300 bg-rose-500/10 border-rose-500/30' },
+  rl: { icon: Rocket, color: 'text-orange-300 bg-orange-500/10 border-orange-500/30' },
+  [CUSTOM_GAME_ID]: {
+    icon: Puzzle,
+    color: 'text-indigo-300 bg-indigo-500/10 border-indigo-500/30',
+  },
 }
 
 const DEFAULT_VISUAL = { icon: Gamepad2, color: 'text-[var(--color-muted-foreground)] bg-[var(--color-muted)] border-[var(--color-border)]' }
@@ -66,12 +79,17 @@ type WizardData = {
   displayName: string
   username: string
   password: string
-  networkId: string
+  gameId: string                // '', a real game id, or CUSTOM_GAME_ID
+  // The single storefront this account lives on. Single-store games auto-fill
+  // this on game pick; multi-store games leave it blank so the user has to
+  // explicitly choose one (Epic OR Steam — different credentials, different
+  // surfaces, so we never bundle them into one record).
+  selectedNetwork: string
   tags: string[]
   notes: string
   riotId: string
   region: string
-  games: string[]
+  alsoPlaysGames: string[]      // sibling games on the same network this account also covers
   customNetwork: string
   customGame: string
 }
@@ -80,34 +98,66 @@ const EMPTY: WizardData = {
   displayName: '',
   username: '',
   password: '',
-  networkId: '',
+  gameId: '',
+  selectedNetwork: '',
   tags: [],
   notes: '',
   riotId: '',
   region: 'na1',
-  games: [],
+  alsoPlaysGames: [],
   customNetwork: '',
   customGame: '',
 }
 
-export function AddAccountWizard({ onClose }: { onClose: () => void }) {
+// stepsFor decides which steps are visible given the current game choice.
+// Single-store games (Valorant, LoL) skip the network step entirely;
+// Custom skips it because the user types their own network label on details.
+function stepsFor(data: WizardData, catalog: CatalogGame[]): Step[] {
+  const steps: Step[] = ['identity', 'game']
+  if (data.gameId && data.gameId !== CUSTOM_GAME_ID) {
+    const game = catalog.find((g) => g.id === data.gameId)
+    if (game && game.networks.length >= 2) steps.push('network')
+  }
+  steps.push('details')
+  return steps
+}
+
+export function AddAccountWizard({
+  onClose,
+  sticky = false,
+}: {
+  onClose: () => void
+  // sticky disables backdrop + Esc dismissal so a misclick can't tear the
+  // user out of an unfinished flow. The Cancel button stays as the explicit
+  // exit. Use during first-account onboarding.
+  sticky?: boolean
+}) {
   const { gameNetworks, addAccount } = useAppStore()
+  const catalog = useMemo(() => buildGamesCatalog(gameNetworks), [gameNetworks])
   const [step, setStep] = useState<Step>('identity')
   const [data, setData] = useState<WizardData>(EMPTY)
   const [submitting, setSubmitting] = useState(false)
 
-  const stepIndex = STEPS.indexOf(step)
-  // Custom network needs a user-provided name before submission — otherwise
+  const steps = useMemo(() => stepsFor(data, catalog), [data, catalog])
+  const stepIndex = Math.max(0, steps.indexOf(step))
+  const isCustom = data.gameId === CUSTOM_GAME_ID
+  const selectedGame = catalog.find((g) => g.id === data.gameId)
+
+  // Custom needs a user-provided network name before submission — otherwise
   // the account would show up as a nameless "Custom" in the list.
   const customReady =
-    data.networkId !== CUSTOM_NETWORK_ID || data.customNetwork.trim().length > 0
+    !isCustom || data.customNetwork.trim().length > 0
+  const networksReady =
+    !steps.includes('network') || data.selectedNetwork.length > 0
+
   const canAdvance =
     (step === 'identity' && data.username.length > 0 && data.password.length > 0) ||
-    (step === 'network' && data.networkId.length > 0) ||
-    (step === 'details' && customReady)
+    (step === 'game' && data.gameId.length > 0) ||
+    (step === 'network' && data.selectedNetwork.length > 0) ||
+    (step === 'details' && customReady && networksReady)
 
   const goBack = () => {
-    if (stepIndex > 0) setStep(STEPS[stepIndex - 1])
+    if (stepIndex > 0) setStep(steps[stepIndex - 1])
     else onClose()
   }
 
@@ -117,28 +167,48 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
       submit()
       return
     }
-    setStep(STEPS[stepIndex + 1])
+    setStep(steps[stepIndex + 1])
   }
 
   const submit = async () => {
     setSubmitting(true)
     try {
-      const isCustom = data.networkId === CUSTOM_NETWORK_ID
-      await addAccount({
-        displayName: data.displayName || data.username,
-        username: data.username,
-        password: data.password,
-        networkId: data.networkId,
-        tags: data.tags,
-        notes: data.notes,
-        // Riot fields only meaningful for the Riot network
-        riotId: isCustom ? '' : data.riotId,
-        region: isCustom ? '' : data.region,
-        games: isCustom ? [] : data.games,
-        customNetwork: isCustom ? data.customNetwork.trim() : '',
-        customGame: isCustom ? data.customGame.trim() : '',
-        cachedRanks: [],
-      })
+      if (isCustom) {
+        await addAccount({
+          displayName: data.displayName || data.username,
+          username: data.username,
+          password: data.password,
+          networkId: CUSTOM_NETWORK_ID,
+          tags: data.tags,
+          notes: data.notes,
+          riotId: '',
+          region: '',
+          games: [],
+          customNetwork: data.customNetwork.trim(),
+          customGame: data.customGame.trim(),
+          cachedRanks: [],
+        })
+      } else {
+        // One record per pick — multi-store games (Rocket League on Epic vs
+        // Steam) require the user to run the wizard again for the second
+        // store, since each storefront uses different credentials.
+        const games = uniqueGames(data.gameId, data.alsoPlaysGames)
+        const networkId = data.selectedNetwork
+        await addAccount({
+          displayName: data.displayName || data.username,
+          username: data.username,
+          password: data.password,
+          networkId,
+          tags: data.tags,
+          notes: data.notes,
+          riotId: networkId === 'riot' ? data.riotId : '',
+          region: networkId === 'riot' ? data.region : '',
+          games,
+          customNetwork: '',
+          customGame: '',
+          cachedRanks: [],
+        })
+      }
       onClose()
     } finally {
       setSubmitting(false)
@@ -148,45 +218,78 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
   const update = <K extends keyof WizardData>(key: K, value: WizardData[K]) =>
     setData((prev) => ({ ...prev, [key]: value }))
 
-  // Picking a network pre-selects all its games (opt-out UX > opt-in).
-  // Switching to a different network resets to that network's full set and
-  // clears any previously-entered custom-network fields.
-  const selectNetwork = (network: models.GameNetwork) =>
+  // Picking a game pre-fills the network only when there's exactly one option
+  // (single-store games like LoL) so the network step can be skipped. For
+  // multi-store games (Rocket League on Epic + Steam) we leave selectedNetwork
+  // blank — the user must explicitly pick a storefront because they're
+  // separate accounts with separate credentials.
+  //
+  // If the chosen network has SharedAccount=true (Riot), every sibling game
+  // on that network is auto-tagged: a Riot login always covers LoL + TFT +
+  // Valorant, so it would be wrong to ask the user to opt in. The DetailsStep
+  // surfaces this as an informational note rather than interactive tiles.
+  const selectGame = (game: CatalogGame) =>
     setData((prev) =>
-      prev.networkId === network.id
+      prev.gameId === game.id
         ? prev
         : {
             ...prev,
-            networkId: network.id,
-            games: network.games.map((g) => g.id),
+            gameId: game.id,
+            selectedNetwork: game.networks.length === 1 ? game.networks[0].id : '',
+            alsoPlaysGames: linkedSiblings(game, gameNetworks),
             customNetwork: '',
             customGame: '',
           },
     )
 
-  // Custom path — no pre-selected games because we don't know what the
-  // network offers. User fills in the label on step 3.
-  const selectCustom = () =>
+  const selectCustomGame = () =>
     setData((prev) =>
-      prev.networkId === CUSTOM_NETWORK_ID ? prev : { ...prev, networkId: CUSTOM_NETWORK_ID, games: [] },
+      prev.gameId === CUSTOM_GAME_ID
+        ? prev
+        : {
+            ...prev,
+            gameId: CUSTOM_GAME_ID,
+            selectedNetwork: CUSTOM_NETWORK_ID,
+            alsoPlaysGames: [],
+          },
     )
 
+  const pickNetwork = (networkId: string) =>
+    setData((prev) => ({ ...prev, selectedNetwork: networkId }))
+
   return (
-    <Modal onClose={onClose} size="md">
-      <WizardHeader step={step} isCustom={data.networkId === CUSTOM_NETWORK_ID} />
+    <Modal
+      onClose={onClose}
+      size="md"
+      dismissOnBackdrop={!sticky}
+      dismissOnEsc={!sticky}
+    >
+      <WizardHeader step={step} steps={steps} isCustom={isCustom} />
 
       <ModalBody className="space-y-3 sm:space-y-4">
         {step === 'identity' && <IdentityStep data={data} update={update} />}
-        {step === 'network' && (
+        {step === 'game' && (
+          <GameStep
+            data={data}
+            catalog={catalog}
+            onSelectGame={selectGame}
+            onSelectCustom={selectCustomGame}
+          />
+        )}
+        {step === 'network' && selectedGame && (
           <NetworkStep
             data={data}
-            onSelectNetwork={selectNetwork}
-            onSelectCustom={selectCustom}
-            networks={gameNetworks}
+            game={selectedGame}
+            onPickNetwork={pickNetwork}
           />
         )}
         {step === 'details' && (
-          <DetailsStep data={data} update={update} networks={gameNetworks} />
+          <DetailsStep
+            data={data}
+            update={update}
+            catalog={catalog}
+            networks={gameNetworks}
+          />
         )}
       </ModalBody>
 
@@ -213,17 +316,49 @@ export function AddAccountWizard({ onClose }: { onClose: () => void }) {
   )
 }
 
-function WizardHeader({ step, isCustom }: { step: Step; isCustom: boolean }) {
+function uniqueGames(primary: string, also: string[]): string[] {
+  const set = new Set<string>([primary, ...also])
+  return Array.from(set)
+}
+
+// linkedSiblings returns the sibling games that share a login with the given
+// game — i.e. games on a SharedAccount network the chosen game lives on.
+// Used to default-tag an account with every game its credentials grant access
+// to (Riot LoL pick → also TFT + Valorant). Returns [] for storefronts where
+// each game is a separate purchase.
+function linkedSiblings(game: CatalogGame, networks: models.GameNetwork[]): string[] {
+  const linked = new Set<string>()
+  for (const cn of game.networks) {
+    if (!cn.sharedAccount) continue
+    const network = networks.find((n) => n.id === cn.id)
+    if (!network) continue
+    for (const g of network.games) {
+      if (g.id !== game.id) linked.add(g.id)
+    }
+  }
+  return Array.from(linked)
+}
+
+function WizardHeader({
+  step,
+  steps,
+  isCustom,
+}: {
+  step: Step
+  steps: Step[]
+  isCustom: boolean
+}) {
   const titles: Record<Step, { title: string; subtitle: string }> = {
     identity: { title: 'Add Account', subtitle: 'Start with your sign-in credentials' },
-    network: { title: 'Choose Network', subtitle: 'Which platform is this account for?' },
+    game: { title: 'Choose Game', subtitle: 'What are you playing?' },
+    network: { title: 'Choose Storefront', subtitle: 'Where do you play this game?' },
     details: {
       title: 'Finishing Touches',
       subtitle: isCustom ? 'Name your platform and you\'re done' : 'All optional — skip to save',
     },
   }
   const { title, subtitle } = titles[step]
-  const stepIndex = STEPS.indexOf(step)
+  const stepIndex = Math.max(0, steps.indexOf(step))
 
   return (
     <div className="p-3 sm:p-4 border-b border-[var(--color-border)] shrink-0">
@@ -235,11 +370,11 @@ function WizardHeader({ step, isCustom }: { step: Step; isCustom: boolean }) {
           <p className="text-xs text-[var(--color-muted-foreground)] truncate">{subtitle}</p>
         </div>
         <span className="text-[10px] sm:text-xs font-medium text-[var(--color-muted-foreground)] shrink-0">
-          Step {stepIndex + 1} of {STEPS.length}
+          Step {stepIndex + 1} of {steps.length}
         </span>
       </div>
       <div className="flex gap-1.5">
-        {STEPS.map((s, i) => (
+        {steps.map((s, i) => (
           <div
             key={s}
             className={cn(
@@ -300,25 +435,24 @@ function IdentityStep({
   )
 }
 
-function NetworkStep({
+function GameStep({
   data,
-  onSelectNetwork,
+  catalog,
+  onSelectGame,
   onSelectCustom,
-  networks,
 }: {
   data: WizardData
-  onSelectNetwork: (network: models.GameNetwork) => void
+  catalog: CatalogGame[]
+  onSelectGame: (game: CatalogGame) => void
   onSelectCustom: () => void
-  networks: models.GameNetwork[]
 }) {
   const [query, setQuery] = useState('')
   const filtered = useMemo(
-    () => networks.filter((n) => fuzzyMatch(query, n.name) || fuzzyMatch(query, n.id)),
-    [networks, query],
+    () => catalog.filter((g) => fuzzyMatch(query, g.name) || fuzzyMatch(query, g.id)),
+    [catalog, query],
   )
-  // The Custom tile is the escape hatch for platforms we don't cover — show it
-  // whenever the query is empty or fuzzy-matches "custom"/"other" so it stays
-  // discoverable, especially when no real networks match.
+  // The Custom tile is the escape hatch for games we don't catalog — keep it
+  // discoverable even when the search filters real games out.
   const q = query.trim().toLowerCase()
   const showCustom =
     q.length === 0 ||
@@ -334,8 +468,8 @@ function NetworkStep({
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search networks"
-          aria-label="Search networks"
+          placeholder="Search games"
+          aria-label="Search games"
           className={cn(
             'w-full pl-9 pr-3 py-2 rounded-lg sm:rounded-xl text-sm',
             'bg-[var(--color-muted)] border border-[var(--color-border)]',
@@ -346,23 +480,27 @@ function NetworkStep({
       </div>
 
       <div className="grid grid-cols-2 gap-2 sm:gap-3">
-        {filtered.map((n) => (
+        {filtered.map((g) => (
           <Tile
-            key={n.id}
-            selected={data.networkId === n.id}
-            onClick={() => onSelectNetwork(n)}
-            visual={NETWORK_VISUAL[n.id] || DEFAULT_VISUAL}
-            title={n.name}
-            subtitle={`${n.games.length} game${n.games.length === 1 ? '' : 's'}`}
+            key={g.id}
+            selected={data.gameId === g.id}
+            onClick={() => onSelectGame(g)}
+            visual={GAME_VISUAL[g.id] || DEFAULT_VISUAL}
+            title={g.name}
+            subtitle={
+              g.networks.length === 1
+                ? g.networks[0].name
+                : `${g.networks.length} stores`
+            }
           />
         ))}
         {showCustom && (
           <Tile
-            selected={data.networkId === CUSTOM_NETWORK_ID}
+            selected={data.gameId === CUSTOM_GAME_ID}
             onClick={onSelectCustom}
-            visual={NETWORK_VISUAL[CUSTOM_NETWORK_ID]}
+            visual={GAME_VISUAL[CUSTOM_GAME_ID]}
             title="Custom"
-            subtitle="Not listed? Name your own"
+            subtitle="Not listed? Add your own"
           />
         )}
       </div>
@@ -376,28 +514,95 @@ function NetworkStep({
   )
 }
 
+function NetworkStep({
+  data,
+  game,
+  onPickNetwork,
+}: {
+  data: WizardData
+  game: CatalogGame
+  onPickNetwork: (networkId: string) => void
+}) {
+  return (
+    <>
+      <p className="text-xs sm:text-sm text-[var(--color-muted-foreground)]">
+        {game.name} ships on {game.networks.length} storefronts. Pick the one
+        this account is for — each store has its own login, so a second store
+        means a second account (run the wizard again).
+      </p>
+
+      <div className="grid grid-cols-2 gap-2 sm:gap-3">
+        {game.networks.map((n) => (
+          <Tile
+            key={n.id}
+            selected={data.selectedNetwork === n.id}
+            onClick={() => onPickNetwork(n.id)}
+            visual={NETWORK_VISUAL[n.id] || DEFAULT_VISUAL}
+            title={n.name}
+            subtitle={data.selectedNetwork === n.id ? 'Selected' : 'Tap to pick'}
+          />
+        ))}
+      </div>
+    </>
+  )
+}
+
 function DetailsStep({
   data,
   update,
+  catalog,
   networks,
 }: {
   data: WizardData
   update: <K extends keyof WizardData>(key: K, value: WizardData[K]) => void
+  catalog: CatalogGame[]
   networks: models.GameNetwork[]
 }) {
   const { tags: availableTags, createTag } = useAppStore()
-  const network = networks.find((n) => n.id === data.networkId)
-  const isCustom = data.networkId === CUSTOM_NETWORK_ID
-  const [gameQuery, setGameQuery] = useState('')
+  const isCustom = data.gameId === CUSTOM_GAME_ID
+  const selectedGame = catalog.find((g) => g.id === data.gameId)
+  const showsRiotFields = !isCustom && data.selectedNetwork === 'riot'
+
+  // Two distinct sibling cases:
+  //   - linkedSiblingsInfo: networks where the login spans every game
+  //     (Riot). Read-only — we surface them as an info note because the user
+  //     can't actually un-link an account from a sibling on the same login.
+  //   - optionalSiblings: networks where each game is a separate purchase
+  //     (Steam/Epic). Render as opt-in tiles for users who happen to play
+  //     siblings on the same account.
+  const linkedSiblingsInfo = useMemo(() => {
+    if (isCustom || !selectedGame || !data.selectedNetwork) return [] as { id: string; name: string }[]
+    const cn = selectedGame.networks.find((n) => n.id === data.selectedNetwork)
+    if (!cn || !cn.sharedAccount) return []
+    const network = networks.find((n) => n.id === cn.id)
+    if (!network) return []
+    return network.games
+      .filter((g) => g.id !== selectedGame.id)
+      .map((g) => ({ id: g.id, name: g.name }))
+  }, [isCustom, selectedGame, data.selectedNetwork, networks])
+
+  const optionalSiblings = useMemo(() => {
+    if (isCustom || !selectedGame || !data.selectedNetwork) return []
+    const cn = selectedGame.networks.find((n) => n.id === data.selectedNetwork)
+    if (!cn || cn.sharedAccount) return [] // shared-account siblings shown as info instead
+    const network = networks.find((n) => n.id === cn.id)
+    if (!network) return []
+    return network.games.filter((g) => g.id !== selectedGame.id)
+  }, [isCustom, selectedGame, data.selectedNetwork, networks])
+
   const [newTag, setNewTag] = useState('')
-  const filteredGames = useMemo(
-    () => (network?.games || []).filter((g) => fuzzyMatch(gameQuery, g.name) || fuzzyMatch(gameQuery, g.id)),
-    [network, gameQuery],
-  )
 
   const toggleTag = (tag: string) => {
     const has = data.tags.includes(tag)
     update('tags', has ? data.tags.filter((t) => t !== tag) : [...data.tags, tag])
+  }
+
+  const toggleAlsoPlays = (gameId: string) => {
+    const has = data.alsoPlaysGames.includes(gameId)
+    update(
+      'alsoPlaysGames',
+      has ? data.alsoPlaysGames.filter((g) => g !== gameId) : [...data.alsoPlaysGames, gameId],
+    )
   }
 
   const addNewTag = async () => {
@@ -418,11 +623,6 @@ function DetailsStep({
     'text-[var(--color-foreground)] placeholder:text-[var(--color-muted-foreground)]',
     'focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]',
   )
-
-  const toggleGame = (gameId: string) => {
-    const has = data.games.includes(gameId)
-    update('games', has ? data.games.filter((g) => g !== gameId) : [...data.games, gameId])
-  }
 
   return (
     <>
@@ -450,38 +650,53 @@ function DetailsStep({
         </>
       )}
 
-      {!isCustom && network && network.games.length > 0 && (
-        <Field label="Games">
-          <div className="relative mb-2">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--color-muted-foreground)]" />
-            <input
-              type="text"
-              value={gameQuery}
-              onChange={(e) => setGameQuery(e.target.value)}
-              placeholder="Search games"
-              aria-label="Search games"
-              className={cn(inputClass, 'pl-9')}
-            />
+      {linkedSiblingsInfo.length > 0 && (
+        <Field label="Linked games">
+          <div
+            role="note"
+            aria-label="Linked games"
+            className={cn(
+              'flex items-start gap-2 px-3 py-2 rounded-lg sm:rounded-xl text-xs',
+              'bg-[var(--color-muted)]/40 border border-[var(--color-border)]',
+              'text-[var(--color-muted-foreground)]',
+            )}
+          >
+            <Check className="w-4 h-4 mt-0.5 text-[var(--color-primary)] shrink-0" />
+            <span>
+              One login covers{' '}
+              <span className="text-[var(--color-foreground)] font-medium">
+                {[selectedGame?.name, ...linkedSiblingsInfo.map((s) => s.name)]
+                  .filter(Boolean)
+                  .join(', ')}
+              </span>
+              {' '}— this account will show up under all of them automatically.
+            </span>
           </div>
+        </Field>
+      )}
+
+      {optionalSiblings.length > 0 && (
+        <Field label="Also plays on this account">
           <div className="grid grid-cols-2 gap-2 sm:gap-3">
-            {filteredGames.map((g) => (
+            {optionalSiblings.map((g) => (
               <Tile
                 key={g.id}
-                selected={data.games.includes(g.id)}
-                onClick={() => toggleGame(g.id)}
+                selected={data.alsoPlaysGames.includes(g.id)}
+                onClick={() => toggleAlsoPlays(g.id)}
                 visual={GAME_VISUAL[g.id] || DEFAULT_VISUAL}
                 title={g.name}
-                subtitle={data.games.includes(g.id) ? 'Selected' : 'Tap to add'}
+                subtitle={data.alsoPlaysGames.includes(g.id) ? 'Selected' : 'Tap to add'}
               />
             ))}
           </div>
           <p className="text-[11px] text-[var(--color-muted-foreground)] mt-1.5">
-            All games selected by default — deselect any you don't play.
+            Each title on this storefront is a separate purchase — tag the
+            extras you happen to own on the same account.
           </p>
         </Field>
       )}
 
-      {data.networkId === 'riot' && (
+      {showsRiotFields && (
         <>
           <Field label="Riot ID">
             <input

--- a/frontend/src/components/__tests__/AddAccountWizard.test.tsx
+++ b/frontend/src/components/__tests__/AddAccountWizard.test.tsx
@@ -5,12 +5,17 @@ import userEvent from '@testing-library/user-event'
 const addAccount = vi.fn()
 const createTag = vi.fn()
 
+// Mock catalog mirrors the production shape: Riot owns three games (single-store
+// each), and Rocket League is the cross-store case shipping under both Epic
+// and Steam — that's the multi-network branch we want to exercise.
 vi.mock('../../stores/appStore', () => ({
   useAppStore: () => ({
     gameNetworks: [
       {
         id: 'riot',
         name: 'Riot Games',
+        // SharedAccount=true encodes that one Riot login spans LoL + TFT + Valorant.
+        sharedAccount: true,
         games: [
           { id: 'lol', name: 'League of Legends', networkId: 'riot' },
           { id: 'tft', name: 'Teamfight Tactics', networkId: 'riot' },
@@ -18,9 +23,16 @@ vi.mock('../../stores/appStore', () => ({
         ],
       },
       {
+        id: 'epic',
+        name: 'Epic Games',
+        sharedAccount: false,
+        games: [{ id: 'rl', name: 'Rocket League', networkId: 'epic' }],
+      },
+      {
         id: 'steam',
         name: 'Steam',
-        games: [{ id: 'cs2', name: 'Counter-Strike 2', networkId: 'steam' }],
+        sharedAccount: false,
+        games: [{ id: 'rl', name: 'Rocket League', networkId: 'steam' }],
       },
     ],
     tags: ['main', 'smurf'],
@@ -30,6 +42,13 @@ vi.mock('../../stores/appStore', () => ({
 }))
 
 import { AddAccountWizard, fuzzyMatch } from '../AddAccountWizard'
+
+// Helper: drive the identity step (always first).
+async function fillIdentity(user: ReturnType<typeof userEvent.setup>, username = 'smurf1', password = 'pw') {
+  await user.type(screen.getByPlaceholderText('Enter username'), username)
+  await user.type(screen.getByPlaceholderText('Enter password'), password)
+  await user.click(screen.getByRole('button', { name: /next/i }))
+}
 
 describe('fuzzyMatch', () => {
   it('matches subsequence regardless of gaps', () => {
@@ -60,7 +79,7 @@ describe('AddAccountWizard', () => {
     expect(pw.type).toBe('password')
   })
 
-  it('requires username and password before advancing from step 1', async () => {
+  it('requires username and password before advancing from the identity step', async () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
 
@@ -74,91 +93,178 @@ describe('AddAccountWizard', () => {
     expect(next).toBeEnabled()
   })
 
-  it('requires network selection before advancing from step 2', async () => {
+  it('shows games (not networks) on the second step — game-first flow', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+    await fillIdentity(user)
+
+    expect(screen.getByRole('button', { name: /league of legends/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /rocket league/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /custom/i })).toBeInTheDocument()
+  })
+
+  it('requires a game pick before advancing', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+    await fillIdentity(user)
+
+    const next = screen.getByRole('button', { name: /next/i })
+    expect(next).toBeDisabled()
+
+    await user.click(screen.getByRole('button', { name: /league of legends/i }))
+    expect(next).toBeEnabled()
+  })
+
+  it('filters game tiles with fuzzy search', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+    await fillIdentity(user)
+
+    expect(screen.getByRole('button', { name: /league of legends/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /rocket league/i })).toBeInTheDocument()
+
+    await user.type(screen.getByLabelText(/search games/i), 'rocket')
+
+    expect(screen.queryByRole('button', { name: /league of legends/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /rocket league/i })).toBeInTheDocument()
+  })
+
+  it('skips the network step for single-store games (League of Legends → Riot only)', async () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
 
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await fillIdentity(user)
+    await user.click(screen.getByRole('button', { name: /league of legends/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
 
-    // Step 2 — network step. Next should be disabled until a tile is picked.
-    const nextOnStep2 = screen.getByRole('button', { name: /next/i })
-    expect(nextOnStep2).toBeDisabled()
-
-    await user.click(screen.getByRole('button', { name: /riot games/i }))
-    expect(nextOnStep2).toBeEnabled()
+    // Should land directly on the details step (Tags label is unique to it).
+    expect(screen.getByText(/^Tags$/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add account/i })).toBeInTheDocument()
   })
 
-  it('filters network tiles with fuzzy search', async () => {
+  it('inserts the network step for cross-store games (Rocket League → Epic + Steam)', async () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
 
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    await fillIdentity(user)
+    await user.click(screen.getByRole('button', { name: /rocket league/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
 
-    // Both networks visible initially
-    expect(screen.getByRole('button', { name: /riot games/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /steam/i })).toBeInTheDocument()
-
-    await user.type(screen.getByLabelText(/search networks/i), 'ste')
-
-    expect(screen.queryByRole('button', { name: /riot games/i })).not.toBeInTheDocument()
+    // Network step shows both stores as tiles.
+    expect(screen.getByRole('button', { name: /epic games/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /steam/i })).toBeInTheDocument()
   })
 
-  it('submits with sensible defaults when user skips step 3', async () => {
+  it('does not pre-pick a store on the network step (forces explicit choice)', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await fillIdentity(user)
+    await user.click(screen.getByRole('button', { name: /rocket league/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Both stores rendered, neither pre-selected — different credentials per
+    // store mean we shouldn't guess.
+    expect(screen.getByRole('button', { name: /epic games/i })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: /steam/i })).toHaveAttribute('aria-pressed', 'false')
+
+    // Next is blocked until one is picked.
+    expect(screen.getByRole('button', { name: /^next$/i })).toBeDisabled()
+  })
+
+  it('network step is single-select — picking a second store swaps the choice', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await fillIdentity(user)
+    await user.click(screen.getByRole('button', { name: /rocket league/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    await user.click(screen.getByRole('button', { name: /epic games/i }))
+    expect(screen.getByRole('button', { name: /epic games/i })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /steam/i })).toHaveAttribute('aria-pressed', 'false')
+
+    // Switching to Steam swaps the selection — no multi-select.
+    await user.click(screen.getByRole('button', { name: /steam/i }))
+    expect(screen.getByRole('button', { name: /epic games/i })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('button', { name: /steam/i })).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('submits exactly one account record for a multi-store game (Steam pick)', async () => {
     const user = userEvent.setup()
     const onClose = vi.fn()
     render(<AddAccountWizard onClose={onClose} />)
 
-    // Step 1
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw123')
+    await fillIdentity(user, 'rl-steam', 'hunter2')
+    await user.click(screen.getByRole('button', { name: /rocket league/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
 
-    // Step 2
-    await user.click(screen.getByRole('button', { name: /riot games/i }))
-    await user.click(screen.getByRole('button', { name: /next/i }))
+    await user.click(screen.getByRole('button', { name: /steam/i }))
+    await user.click(screen.getByRole('button', { name: /^next$/i }))
 
-    // Step 3 — skip straight to Add Account
+    // Submit label is always plain "Add Account" — no batch creation.
     await user.click(screen.getByRole('button', { name: /add account/i }))
 
     expect(addAccount).toHaveBeenCalledTimes(1)
     const payload = addAccount.mock.calls[0][0]
-    expect(payload.username).toBe('smurf1')
-    expect(payload.password).toBe('pw123')
-    expect(payload.networkId).toBe('riot')
-    expect(payload.displayName).toBe('smurf1') // defaults to username
-    expect(payload.games).toEqual(['lol', 'tft', 'valorant']) // defaults to all network games
-    expect(payload.region).toBe('na1')
+    expect(payload.networkId).toBe('steam')
+    expect(payload.username).toBe('rl-steam')
+    expect(payload.games).toEqual(['rl'])
+    expect(payload.riotId).toBe('')
+    expect(payload.region).toBe('')
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('pre-selects all games when a network is picked (opt-out UX)', async () => {
+  it('shows Riot ID + Region only when the chosen game lives on Riot', async () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
 
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
+    // Rocket League → Epic + Steam: no Riot fields on details.
+    await fillIdentity(user)
+    await user.click(screen.getByRole('button', { name: /rocket league/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
-    await user.click(screen.getByRole('button', { name: /riot games/i }))
+    await user.click(screen.getByRole('button', { name: /^next$/i }))
+
+    expect(screen.queryByPlaceholderText(/GameName#TAG/i)).not.toBeInTheDocument()
+  })
+
+  it('shows Riot ID + Region for League of Legends (Riot game)', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await fillIdentity(user)
+    await user.click(screen.getByRole('button', { name: /league of legends/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
 
-    // On step 3 every Riot game tile should already be selected.
-    expect(screen.getByRole('button', { name: /league of legends/i })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    )
-    expect(screen.getByRole('button', { name: /teamfight tactics/i })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    )
-    expect(screen.getByRole('button', { name: /valorant/i })).toHaveAttribute(
-      'aria-pressed',
-      'true',
-    )
+    expect(screen.getByPlaceholderText(/GameName#TAG/i)).toBeInTheDocument()
+  })
+
+  it('auto-links Riot sibling games (one login covers LoL + TFT + Valorant)', async () => {
+    const user = userEvent.setup()
+    render(<AddAccountWizard onClose={vi.fn()} />)
+
+    await fillIdentity(user, 'riot-main', 'pw')
+    await user.click(screen.getByRole('button', { name: /league of legends/i }))
+    await user.click(screen.getByRole('button', { name: /next/i }))
+
+    // Shared-account networks render an info note instead of opt-in tiles —
+    // the user can't (and shouldn't be able to) un-link siblings on the same
+    // login. The note must mention the sibling games so it's discoverable.
+    const note = screen.getByRole('note', { name: /linked games/i })
+    expect(note).toHaveTextContent(/league of legends/i)
+    expect(note).toHaveTextContent(/teamfight tactics/i)
+    expect(note).toHaveTextContent(/valorant/i)
+
+    // No interactive tiles for TFT/Valorant on this step (the only buttons
+    // labeled with their names live on the game-step which is no longer rendered).
+    expect(screen.queryByRole('button', { name: /teamfight tactics/i })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /add account/i }))
+
+    expect(addAccount).toHaveBeenCalledTimes(1)
+    const games: string[] = addAccount.mock.calls[0][0].games
+    // Order isn't load-bearing — assert membership.
+    expect(games.sort()).toEqual(['lol', 'tft', 'valorant'])
   })
 
   it('lets the user toggle existing tags and create new ones', async () => {
@@ -167,17 +273,12 @@ describe('AddAccountWizard', () => {
     const onClose = vi.fn()
     render(<AddAccountWizard onClose={onClose} />)
 
-    // Advance to step 3
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
-    await user.click(screen.getByRole('button', { name: /next/i }))
-    await user.click(screen.getByRole('button', { name: /riot games/i }))
+    await fillIdentity(user)
+    await user.click(screen.getByRole('button', { name: /league of legends/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
 
-    // Toggle existing tag
-    await user.click(screen.getByRole('button', { name: /main/i }))
+    await user.click(screen.getByRole('button', { name: /^main$/i }))
 
-    // Create a brand new tag via Enter key
     const tagInput = screen.getByLabelText(/create a new tag/i)
     await user.type(tagInput, 'ranked-grind{Enter}')
 
@@ -194,40 +295,30 @@ describe('AddAccountWizard', () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
 
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
-    await user.click(screen.getByRole('button', { name: /next/i }))
-
+    await fillIdentity(user)
     await user.click(screen.getByRole('button', { name: /back/i }))
 
     expect(screen.getByPlaceholderText('Enter username')).toHaveValue('smurf1')
     expect(screen.getByPlaceholderText('Enter password')).toHaveValue('pw')
   })
 
-  it('shows a Custom tile on the network step as an escape hatch', async () => {
+  it('shows a Custom tile on the game step as an escape hatch', async () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
-
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
-    await user.click(screen.getByRole('button', { name: /next/i }))
+    await fillIdentity(user)
 
     expect(screen.getByRole('button', { name: /custom/i })).toBeInTheDocument()
   })
 
-  it('still shows Custom when no networks match the query', async () => {
+  it('still shows Custom when no games match the search query', async () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
+    await fillIdentity(user)
 
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
-    await user.click(screen.getByRole('button', { name: /next/i }))
+    await user.type(screen.getByLabelText(/search games/i), 'zzznotagame')
 
-    // Type a nonsense query that matches no real network
-    await user.type(screen.getByLabelText(/search networks/i), 'zzzzfortnite')
-
-    expect(screen.queryByRole('button', { name: /riot games/i })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: /steam/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /league of legends/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /rocket league/i })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: /custom/i })).toBeInTheDocument()
   })
 
@@ -235,20 +326,14 @@ describe('AddAccountWizard', () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
 
-    // Step 1
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
-    await user.click(screen.getByRole('button', { name: /next/i }))
-
-    // Step 2 — pick Custom
+    await fillIdentity(user)
     await user.click(screen.getByRole('button', { name: /custom/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
 
-    // Step 3 — Add Account should be disabled until network name is entered
     const submit = screen.getByRole('button', { name: /add account/i })
     expect(submit).toBeDisabled()
 
-    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Steam')
+    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Battle.net')
     expect(submit).toBeEnabled()
   })
 
@@ -257,45 +342,36 @@ describe('AddAccountWizard', () => {
     const onClose = vi.fn()
     render(<AddAccountWizard onClose={onClose} />)
 
-    // Step 1
-    await user.type(screen.getByPlaceholderText('Enter username'), 'cs-main')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'hunter2')
-    await user.click(screen.getByRole('button', { name: /next/i }))
-
-    // Step 2 — Custom
+    await fillIdentity(user, 'cs-main', 'hunter2')
     await user.click(screen.getByRole('button', { name: /custom/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
 
-    // Step 3 — custom inputs
-    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Steam')
-    await user.type(screen.getByPlaceholderText(/cs2, apex legends/i), 'Counter-Strike 2')
+    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Battle.net')
+    await user.type(screen.getByPlaceholderText(/cs2, apex legends/i), 'Overwatch 2')
     await user.click(screen.getByRole('button', { name: /add account/i }))
 
     expect(addAccount).toHaveBeenCalledTimes(1)
     const payload = addAccount.mock.calls[0][0]
     expect(payload.networkId).toBe('custom')
-    expect(payload.customNetwork).toBe('Steam')
-    expect(payload.customGame).toBe('Counter-Strike 2')
+    expect(payload.customNetwork).toBe('Battle.net')
+    expect(payload.customGame).toBe('Overwatch 2')
     expect(payload.games).toEqual([])
     expect(payload.riotId).toBe('')
     expect(payload.region).toBe('')
     expect(onClose).toHaveBeenCalled()
   })
 
-  it('clears custom fields when switching back from Custom to a real network', async () => {
+  it('clears custom fields when switching back from Custom to a real game', async () => {
     const user = userEvent.setup()
     render(<AddAccountWizard onClose={vi.fn()} />)
 
-    await user.type(screen.getByPlaceholderText('Enter username'), 'smurf1')
-    await user.type(screen.getByPlaceholderText('Enter password'), 'pw')
-    await user.click(screen.getByRole('button', { name: /next/i }))
+    await fillIdentity(user)
 
-    // Pick Custom, fill the name, then switch to Riot
     await user.click(screen.getByRole('button', { name: /custom/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
-    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Steam')
+    await user.type(screen.getByPlaceholderText(/steam, epic games/i), 'Battle.net')
     await user.click(screen.getByRole('button', { name: /back/i }))
-    await user.click(screen.getByRole('button', { name: /riot games/i }))
+    await user.click(screen.getByRole('button', { name: /league of legends/i }))
     await user.click(screen.getByRole('button', { name: /next/i }))
     await user.click(screen.getByRole('button', { name: /add account/i }))
 
@@ -303,6 +379,52 @@ describe('AddAccountWizard', () => {
     expect(payload.networkId).toBe('riot')
     expect(payload.customNetwork).toBe('')
     expect(payload.customGame).toBe('')
-    expect(payload.games).toEqual(['lol', 'tft', 'valorant'])
+    // Riot SharedAccount=true means the LoL pick auto-tags TFT + Valorant too.
+    expect([...payload.games].sort()).toEqual(['lol', 'tft', 'valorant'])
+  })
+
+  describe('sticky mode (first-account onboarding)', () => {
+    it('ignores backdrop clicks — only Cancel exits', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      const { container } = render(<AddAccountWizard onClose={onClose} sticky />)
+
+      // The backdrop is the outermost fixed-inset wrapper rendered by Modal.
+      const backdrop = container.querySelector('.fixed.inset-0') as HTMLElement
+      expect(backdrop).toBeTruthy()
+      await user.click(backdrop)
+
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('ignores the Escape key', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<AddAccountWizard onClose={onClose} sticky />)
+
+      await user.keyboard('{Escape}')
+
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('still closes when the user clicks Cancel', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      render(<AddAccountWizard onClose={onClose} sticky />)
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }))
+      expect(onClose).toHaveBeenCalled()
+    })
+
+    it('non-sticky mode (default) still allows backdrop dismissal', async () => {
+      const user = userEvent.setup()
+      const onClose = vi.fn()
+      const { container } = render(<AddAccountWizard onClose={onClose} />)
+
+      const backdrop = container.querySelector('.fixed.inset-0') as HTMLElement
+      await user.click(backdrop)
+
+      expect(onClose).toHaveBeenCalled()
+    })
   })
 })

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -12,7 +12,12 @@ import { cn } from '../../lib/utils'
 interface Props {
   onClose: () => void
   size?: 'sm' | 'md' | 'lg'
+  // When false, clicking the blurred backdrop is a no-op. Use for high-stakes
+  // flows where a misclick would lose work the user can't easily restart.
   dismissOnBackdrop?: boolean
+  // When false, the Escape key is also a no-op. Pair with dismissOnBackdrop=false
+  // when the modal must only close via an explicit in-modal action.
+  dismissOnEsc?: boolean
   className?: string
   children: ReactNode
 }
@@ -23,21 +28,28 @@ const SIZE_CLASSES: Record<NonNullable<Props['size']>, string> = {
   lg: 'max-w-[95%] sm:max-w-lg',
 }
 
-export function Modal({ onClose, size = 'md', dismissOnBackdrop = true, className, children }: Props) {
+export function Modal({
+  onClose,
+  size = 'md',
+  dismissOnBackdrop = true,
+  dismissOnEsc = true,
+  className,
+  children,
+}: Props) {
   // Lock body scroll while open — prevents the list behind the modal from
   // scrolling when the user hits space/arrow keys.
   useEffect(() => {
     const prev = document.body.style.overflow
     document.body.style.overflow = 'hidden'
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape' && dismissOnEsc) onClose()
     }
     window.addEventListener('keydown', onKey)
     return () => {
       document.body.style.overflow = prev
       window.removeEventListener('keydown', onKey)
     }
-  }, [onClose])
+  }, [onClose, dismissOnEsc])
 
   return (
     <div

--- a/frontend/src/lib/__tests__/catalog.test.ts
+++ b/frontend/src/lib/__tests__/catalog.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { buildGamesCatalog } from '../catalog'
+import type { models } from '../../../wailsjs/go/models'
+
+// Wails generates models as classes (with a runtime convertValues method),
+// but tests only need the JSON-shaped data. Cast through unknown so the
+// fixtures stay readable.
+const game = (id: string, name: string, networkId: string): models.Game =>
+  ({ id, name, networkId, clientProcess: {}, clientTitle: '', gameProcesses: {} }) as unknown as models.Game
+
+const network = (
+  id: string,
+  name: string,
+  games: models.Game[],
+  opts: { sharedAccount?: boolean } = {},
+): models.GameNetwork =>
+  ({ id, name, games, sharedAccount: opts.sharedAccount ?? false }) as unknown as models.GameNetwork
+
+describe('buildGamesCatalog', () => {
+  it('produces one entry per game with its network listed', () => {
+    const catalog = buildGamesCatalog([
+      network('riot', 'Riot Games', [game('lol', 'League of Legends', 'riot')]),
+    ])
+
+    expect(catalog).toHaveLength(1)
+    expect(catalog[0].id).toBe('lol')
+    expect(catalog[0].networks).toEqual([
+      { id: 'riot', name: 'Riot Games', sharedAccount: false },
+    ])
+  })
+
+  it('merges a cross-store game (e.g. Rocket League) into a single entry with both networks', () => {
+    const catalog = buildGamesCatalog([
+      network('epic', 'Epic Games', [game('rl', 'Rocket League', 'epic')]),
+      network('steam', 'Steam', [game('rl', 'Rocket League', 'steam')]),
+    ])
+
+    expect(catalog).toHaveLength(1)
+    expect(catalog[0].id).toBe('rl')
+    expect(catalog[0].networks.map((n) => n.id)).toEqual(['epic', 'steam'])
+  })
+
+  it('preserves source order — first-seen game wins its slot', () => {
+    const catalog = buildGamesCatalog([
+      network('riot', 'Riot', [
+        game('lol', 'League', 'riot'),
+        game('tft', 'TFT', 'riot'),
+      ]),
+      network('epic', 'Epic', [game('rl', 'RL', 'epic')]),
+    ])
+    expect(catalog.map((g) => g.id)).toEqual(['lol', 'tft', 'rl'])
+  })
+
+  it('does not duplicate a network if the same game appears twice under it', () => {
+    const catalog = buildGamesCatalog([
+      network('riot', 'Riot', [
+        game('lol', 'League', 'riot'),
+        game('lol', 'League', 'riot'),
+      ]),
+    ])
+    expect(catalog).toHaveLength(1)
+    expect(catalog[0].networks).toHaveLength(1)
+  })
+
+  it('propagates sharedAccount onto each catalog network entry', () => {
+    const catalog = buildGamesCatalog([
+      network('riot', 'Riot', [game('lol', 'League', 'riot')], { sharedAccount: true }),
+      network('epic', 'Epic', [game('rl', 'RL', 'epic')], { sharedAccount: false }),
+    ])
+    const lol = catalog.find((g) => g.id === 'lol')!
+    const rl = catalog.find((g) => g.id === 'rl')!
+    expect(lol.networks[0].sharedAccount).toBe(true)
+    expect(rl.networks[0].sharedAccount).toBe(false)
+  })
+
+  it('defaults sharedAccount to false when the source omits it', () => {
+    const raw = { id: 'epic', name: 'Epic', games: [game('rl', 'RL', 'epic')] } as unknown as models.GameNetwork
+    const catalog = buildGamesCatalog([raw])
+    expect(catalog[0].networks[0].sharedAccount).toBe(false)
+  })
+})

--- a/frontend/src/lib/catalog.ts
+++ b/frontend/src/lib/catalog.ts
@@ -1,0 +1,55 @@
+import { models } from '../../wailsjs/go/models'
+
+// CatalogNetwork describes one storefront a game ships on, carrying the
+// sharedAccount flag so wizards can decide whether to auto-link sibling games
+// (Riot binds one login to every Riot game; Steam/Epic don't).
+export type CatalogNetwork = {
+  id: string
+  name: string
+  sharedAccount: boolean
+}
+
+// CatalogGame is the game-first projection of GameNetwork[]: one entry per
+// unique game.id, with the list of networks that ship it. Used by the
+// AddAccountWizard so users pick "Rocket League" first and only choose a
+// storefront when the game lives on more than one (Epic + Steam).
+export type CatalogGame = {
+  id: string
+  name: string
+  networks: CatalogNetwork[]
+}
+
+// buildGamesCatalog flattens GameNetwork[] into one CatalogGame per game.id,
+// preserving the source network order so Riot games appear before Epic/Steam
+// titles when the underlying catalog is in that order. A game shared across
+// stores (like Rocket League under both Epic and Steam) appears once with two
+// network entries.
+export function buildGamesCatalog(networks: models.GameNetwork[]): CatalogGame[] {
+  const order: string[] = []
+  const byId = new Map<string, CatalogGame>()
+
+  for (const network of networks) {
+    const entry: CatalogNetwork = {
+      id: network.id,
+      name: network.name,
+      sharedAccount: Boolean(network.sharedAccount),
+    }
+    for (const game of network.games) {
+      const existing = byId.get(game.id)
+      if (existing) {
+        if (!existing.networks.some((n) => n.id === network.id)) {
+          existing.networks.push(entry)
+        }
+        continue
+      }
+      byId.set(game.id, {
+        id: game.id,
+        name: game.name,
+        networks: [entry],
+      })
+      order.push(game.id)
+    }
+  }
+
+  return order.map((id) => byId.get(id)!)
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -40,6 +40,15 @@ type GameNetwork struct {
 	ID    string `json:"id"`
 	Name  string `json:"name"`
 	Games []Game `json:"games"`
+
+	// SharedAccount is true when one login spans every game on the network —
+	// e.g. a Riot account is always LoL + TFT + Valorant; Battle.net works
+	// the same way across WoW/Diablo/Overwatch. When true, picking any one
+	// game implicitly grants access to its siblings, and the wizard auto-tags
+	// new accounts with the full game list rather than asking the user to
+	// opt in game-by-game. Storefronts like Steam/Epic stay false because
+	// each title there is a separate purchase.
+	SharedAccount bool `json:"sharedAccount,omitempty"`
 }
 
 // Game represents a specific game within a network
@@ -196,13 +205,23 @@ type Settings struct {
 	DefaultRegion string `json:"defaultRegion,omitempty"` // e.g., "na1", "euw1"
 }
 
+// Rocket League process names are shared between the Epic and Steam editions —
+// Psyonix ships the same executable on both storefronts. Keep them in one place
+// so the Epic/Steam network entries below stay in sync.
+var rocketLeagueGameProcesses = PlatformProcesses{
+	Windows: []string{"RocketLeague.exe"},
+	// macOS/Linux: Psyonix dropped native builds in 2020; no native process
+	// names to watch.
+}
+
 // DefaultGameNetworks returns pre-populated game networks with platform-specific process names
 // Only native ports are defined - empty means game doesn't exist on that platform
 func DefaultGameNetworks() []GameNetwork {
 	return []GameNetwork{
 		{
-			ID:   "riot",
-			Name: "Riot Games",
+			ID:            "riot",
+			Name:          "Riot Games",
+			SharedAccount: true,
 			Games: []Game{
 				{
 					ID:        "lol",
@@ -251,6 +270,44 @@ func DefaultGameNetworks() []GameNetwork {
 						MacOS:   []string{"League of Legends"},
 						// Linux: no native client
 					},
+				},
+			},
+		},
+		{
+			ID:   "epic",
+			Name: "Epic Games",
+			Games: []Game{
+				{
+					ID:        "rl",
+					Name:      "Rocket League",
+					NetworkID: "epic",
+					// The Epic launcher is the persistent "signed in" surface —
+					// there's no Rocket-League-specific client like LeagueClient.
+					ClientProcess: PlatformProcesses{
+						Windows: []string{"EpicGamesLauncher.exe"},
+						MacOS:   []string{"Epic Games Launcher"},
+						// Linux: no native Epic launcher
+					},
+					ClientTitle:   "Epic Games Launcher",
+					GameProcesses: rocketLeagueGameProcesses,
+				},
+			},
+		},
+		{
+			ID:   "steam",
+			Name: "Steam",
+			Games: []Game{
+				{
+					ID:        "rl",
+					Name:      "Rocket League",
+					NetworkID: "steam",
+					ClientProcess: PlatformProcesses{
+						Windows: []string{"steam.exe"},
+						MacOS:   []string{"steam_osx", "Steam"},
+						Linux:   []string{"steam"},
+					},
+					ClientTitle:   "Steam",
+					GameProcesses: rocketLeagueGameProcesses,
 				},
 			},
 		},

--- a/internal/models/models_test.go
+++ b/internal/models/models_test.go
@@ -1,0 +1,101 @@
+package models
+
+import "testing"
+
+// TestRocketLeagueUnderEpicAndSteam pins the cross-platform contract that
+// Rocket League ships under both storefronts. A regression here would mean
+// accounts from one store silently disappear from the picker.
+func TestRocketLeagueUnderEpicAndSteam(t *testing.T) {
+	networks := DefaultGameNetworks()
+
+	// Build a lookup so the assertions read linearly.
+	byNetwork := map[string]*Game{}
+	for i := range networks {
+		for j := range networks[i].Games {
+			g := &networks[i].Games[j]
+			if g.ID == "rl" {
+				byNetwork[networks[i].ID] = g
+			}
+		}
+	}
+
+	for _, networkID := range []string{"epic", "steam"} {
+		g, ok := byNetwork[networkID]
+		if !ok {
+			t.Errorf("Rocket League missing under network %q", networkID)
+			continue
+		}
+		if g.NetworkID != networkID {
+			t.Errorf("network %q: Rocket League game.NetworkID = %q, want %q",
+				networkID, g.NetworkID, networkID)
+		}
+		if len(g.GameProcesses.Windows) == 0 {
+			t.Errorf("network %q: Rocket League must declare at least one Windows game process",
+				networkID)
+		}
+		if len(g.ClientProcess.Windows) == 0 {
+			t.Errorf("network %q: launcher must declare at least one Windows client process",
+				networkID)
+		}
+	}
+}
+
+// TestRocketLeagueSharesGameProcessesAcrossStores pins the invariant that
+// Psyonix ships the same RocketLeague.exe regardless of storefront. If the
+// binary ever diverges we want an explicit change site, not a silent drift.
+func TestRocketLeagueSharesGameProcessesAcrossStores(t *testing.T) {
+	var epicRL, steamRL []string
+	for _, n := range DefaultGameNetworks() {
+		for _, g := range n.Games {
+			if g.ID != "rl" {
+				continue
+			}
+			switch n.ID {
+			case "epic":
+				epicRL = g.GameProcesses.Windows
+			case "steam":
+				steamRL = g.GameProcesses.Windows
+			}
+		}
+	}
+	if len(epicRL) == 0 || len(steamRL) == 0 {
+		t.Fatalf("expected Rocket League under both stores, got epic=%v steam=%v", epicRL, steamRL)
+	}
+	if !equalStringSlice(epicRL, steamRL) {
+		t.Errorf("Rocket League game processes diverged across stores: epic=%v, steam=%v",
+			epicRL, steamRL)
+	}
+}
+
+// TestSharedAccountFlag pins the platform-truth invariants the wizard relies
+// on: Riot binds one login to every Riot game (LoL/TFT/Valorant); Steam and
+// Epic do not. A regression here would cause the wizard to either over-tag
+// Steam/Epic accounts with sibling games or under-tag Riot accounts.
+func TestSharedAccountFlag(t *testing.T) {
+	want := map[string]bool{
+		"riot":  true,
+		"epic":  false,
+		"steam": false,
+	}
+	for _, n := range DefaultGameNetworks() {
+		expected, ok := want[n.ID]
+		if !ok {
+			continue
+		}
+		if n.SharedAccount != expected {
+			t.Errorf("network %q: SharedAccount = %v, want %v", n.ID, n.SharedAccount, expected)
+		}
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/providers/epic/provider.go
+++ b/internal/providers/epic/provider.go
@@ -1,0 +1,92 @@
+// Package epic implements the providers.Provider interface for the Epic
+// Games storefront. It currently covers Rocket League but will extend to
+// other Epic-distributed titles as they're added to models.DefaultGameNetworks.
+//
+// Unlike the Riot provider, Epic does not expose a local LCU-style API we
+// can query for the signed-in account, so Detect reports a stable
+// "not signed in" DetectionError even when the launcher is running. The
+// launcher presence is still surfaced via IsClientRunning so the polling
+// loop can keep the UI in the "client active" state while the user decides
+// who is playing.
+package epic
+
+import (
+	"context"
+
+	"OpenSmurfManager/internal/models"
+	"OpenSmurfManager/internal/process"
+	"OpenSmurfManager/internal/providers"
+)
+
+// NetworkID is the stable identifier for the Epic Games provider.
+const NetworkID = "epic"
+
+// Provider implements providers.Provider for Epic Games titles.
+type Provider struct{}
+
+// New returns a new Epic provider instance.
+func New() *Provider {
+	return &Provider{}
+}
+
+// NetworkID returns "epic".
+func (p *Provider) NetworkID() string {
+	return NetworkID
+}
+
+// DisplayName returns "Epic Games".
+func (p *Provider) DisplayName() string {
+	return "Epic Games"
+}
+
+// IsClientRunning checks for the Epic Games launcher process. Running titles
+// like Rocket League are reported via models.Game.GameProcesses and handled
+// separately by app.IsInGame.
+func (p *Provider) IsClientRunning(_ context.Context) bool {
+	return process.AnyRunning(collectClientProcesses())
+}
+
+// Detect currently cannot identify the signed-in Epic account without OAuth
+// or filesystem scraping, so it always returns a structured DetectionError.
+// Callers treat this as "platform seen but session unknown" and fall through
+// to the next provider in the registry.
+func (p *Provider) Detect(ctx context.Context) (*providers.DetectedAccount, error) {
+	if !p.IsClientRunning(ctx) {
+		return nil, &providers.DetectionError{
+			Code:    providers.ErrCodeClientOffline,
+			Message: "Epic Games Launcher is not running",
+			Retry:   true,
+		}
+	}
+	return nil, &providers.DetectionError{
+		Code:    providers.ErrCodeNotSignedIn,
+		Message: "Epic Games account auto-detection is not yet supported",
+		Retry:   false,
+	}
+}
+
+// MatchAccount returns nil because we have no reliable Epic-side identifier
+// to match against yet. Users still get value from the provider by manually
+// tagging accounts with NetworkID="epic" — the rest of the app treats those
+// as first-class entries.
+func (p *Provider) MatchAccount(_ []models.Account, _ *providers.DetectedAccount) *models.Account {
+	return nil
+}
+
+// UpdateAccount is a noop — with no Detect payload we have nothing to merge.
+func (p *Provider) UpdateAccount(_ *models.Account, _ *providers.DetectedAccount) {}
+
+// collectClientProcesses gathers all Epic launcher process names for the
+// current platform from the default game network definitions.
+func collectClientProcesses() []string {
+	var names []string
+	for _, network := range models.DefaultGameNetworks() {
+		if network.ID != NetworkID {
+			continue
+		}
+		for _, game := range network.Games {
+			names = append(names, game.ClientProcess.ForCurrentPlatform()...)
+		}
+	}
+	return names
+}

--- a/internal/providers/epic/provider_test.go
+++ b/internal/providers/epic/provider_test.go
@@ -1,0 +1,64 @@
+package epic_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"OpenSmurfManager/internal/models"
+	"OpenSmurfManager/internal/providers"
+	"OpenSmurfManager/internal/providers/contract"
+	"OpenSmurfManager/internal/providers/epic"
+)
+
+// TestEpicProvider_Contract runs the standard provider conformance suite
+// against the Epic adapter. Live detection is not meaningful here (Detect
+// always returns a structured DetectionError today), but the contract's
+// offline path still applies.
+func TestEpicProvider_Contract(t *testing.T) {
+	contract.RunContractTests(t, contract.Suite{
+		Factory: func() providers.Provider { return epic.New() },
+	})
+}
+
+// TestEpicProvider_NetworkIDMatchesModel ensures the provider's NetworkID
+// lines up with the entry registered in models.DefaultGameNetworks — a
+// mismatch would silently hide Epic accounts from the polling loop.
+func TestEpicProvider_NetworkIDMatchesModel(t *testing.T) {
+	p := epic.New()
+	for _, n := range models.DefaultGameNetworks() {
+		if n.ID == p.NetworkID() {
+			return
+		}
+	}
+	t.Fatalf("epic provider NetworkID %q not present in DefaultGameNetworks", p.NetworkID())
+}
+
+// TestEpicProvider_DetectReportsNotSignedInOrOffline verifies that Detect
+// always returns a structured DetectionError — account auto-detection is
+// intentionally unimplemented today, and the registry relies on the stable
+// error codes to move on to the next provider.
+func TestEpicProvider_DetectReportsNotSignedInOrOffline(t *testing.T) {
+	p := epic.New()
+	detected, err := p.Detect(context.Background())
+
+	if detected != nil {
+		t.Fatalf("Detect must not return a detected account yet, got %#v", detected)
+	}
+	if err == nil {
+		t.Fatal("Detect must return a DetectionError, got nil")
+	}
+
+	var detErr *providers.DetectionError
+	if !errors.As(err, &detErr) {
+		t.Fatalf("Detect must return *providers.DetectionError, got %T: %v", err, err)
+	}
+
+	// Either code is acceptable depending on whether the launcher is running
+	// on the test host. Both are structured signals, which is the contract.
+	switch detErr.Code {
+	case providers.ErrCodeClientOffline, providers.ErrCodeNotSignedIn:
+	default:
+		t.Fatalf("unexpected DetectionError.Code %q", detErr.Code)
+	}
+}

--- a/internal/providers/steam/provider.go
+++ b/internal/providers/steam/provider.go
@@ -1,0 +1,88 @@
+// Package steam implements the providers.Provider interface for the Steam
+// storefront. It currently covers Rocket League but will extend to other
+// Steam titles as they're added to models.DefaultGameNetworks.
+//
+// Steam exposes persistent user data under a local directory (loginusers.vdf,
+// config.vdf), but parsing those is deferred: this first cut reports
+// launcher presence only and returns a structured DetectionError from
+// Detect so the registry can move on to the next provider.
+package steam
+
+import (
+	"context"
+
+	"OpenSmurfManager/internal/models"
+	"OpenSmurfManager/internal/process"
+	"OpenSmurfManager/internal/providers"
+)
+
+// NetworkID is the stable identifier for the Steam provider.
+const NetworkID = "steam"
+
+// Provider implements providers.Provider for Steam titles.
+type Provider struct{}
+
+// New returns a new Steam provider instance.
+func New() *Provider {
+	return &Provider{}
+}
+
+// NetworkID returns "steam".
+func (p *Provider) NetworkID() string {
+	return NetworkID
+}
+
+// DisplayName returns "Steam".
+func (p *Provider) DisplayName() string {
+	return "Steam"
+}
+
+// IsClientRunning checks for the Steam client process. A running game (e.g.
+// RocketLeague.exe) is tracked separately via models.Game.GameProcesses.
+func (p *Provider) IsClientRunning(_ context.Context) bool {
+	return process.AnyRunning(collectClientProcesses())
+}
+
+// Detect cannot yet resolve the signed-in Steam account without parsing
+// loginusers.vdf or talking to a Steam Web API key, so it returns a stable
+// DetectionError. The registry treats that as "client seen but session
+// unknown" and moves on.
+func (p *Provider) Detect(ctx context.Context) (*providers.DetectedAccount, error) {
+	if !p.IsClientRunning(ctx) {
+		return nil, &providers.DetectionError{
+			Code:    providers.ErrCodeClientOffline,
+			Message: "Steam is not running",
+			Retry:   true,
+		}
+	}
+	return nil, &providers.DetectionError{
+		Code:    providers.ErrCodeNotSignedIn,
+		Message: "Steam account auto-detection is not yet supported",
+		Retry:   false,
+	}
+}
+
+// MatchAccount returns nil because we have no reliable Steam-side identifier
+// to match against yet. Users still get value from manually tagging accounts
+// with NetworkID="steam" — the rest of the app treats those as first-class.
+func (p *Provider) MatchAccount(_ []models.Account, _ *providers.DetectedAccount) *models.Account {
+	return nil
+}
+
+// UpdateAccount is a noop — with no Detect payload we have nothing to merge.
+func (p *Provider) UpdateAccount(_ *models.Account, _ *providers.DetectedAccount) {}
+
+// collectClientProcesses gathers all Steam launcher process names for the
+// current platform from the default game network definitions.
+func collectClientProcesses() []string {
+	var names []string
+	for _, network := range models.DefaultGameNetworks() {
+		if network.ID != NetworkID {
+			continue
+		}
+		for _, game := range network.Games {
+			names = append(names, game.ClientProcess.ForCurrentPlatform()...)
+		}
+	}
+	return names
+}

--- a/internal/providers/steam/provider_test.go
+++ b/internal/providers/steam/provider_test.go
@@ -1,0 +1,58 @@
+package steam_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"OpenSmurfManager/internal/models"
+	"OpenSmurfManager/internal/providers"
+	"OpenSmurfManager/internal/providers/contract"
+	"OpenSmurfManager/internal/providers/steam"
+)
+
+// TestSteamProvider_Contract runs the standard provider conformance suite
+// against the Steam adapter.
+func TestSteamProvider_Contract(t *testing.T) {
+	contract.RunContractTests(t, contract.Suite{
+		Factory: func() providers.Provider { return steam.New() },
+	})
+}
+
+// TestSteamProvider_NetworkIDMatchesModel ensures the provider's NetworkID
+// matches the entry registered in models.DefaultGameNetworks.
+func TestSteamProvider_NetworkIDMatchesModel(t *testing.T) {
+	p := steam.New()
+	for _, n := range models.DefaultGameNetworks() {
+		if n.ID == p.NetworkID() {
+			return
+		}
+	}
+	t.Fatalf("steam provider NetworkID %q not present in DefaultGameNetworks", p.NetworkID())
+}
+
+// TestSteamProvider_DetectReportsNotSignedInOrOffline verifies that Detect
+// always returns a structured DetectionError — Steam auto-detection is not
+// implemented yet, and the registry relies on the stable error codes.
+func TestSteamProvider_DetectReportsNotSignedInOrOffline(t *testing.T) {
+	p := steam.New()
+	detected, err := p.Detect(context.Background())
+
+	if detected != nil {
+		t.Fatalf("Detect must not return a detected account yet, got %#v", detected)
+	}
+	if err == nil {
+		t.Fatal("Detect must return a DetectionError, got nil")
+	}
+
+	var detErr *providers.DetectionError
+	if !errors.As(err, &detErr) {
+		t.Fatalf("Detect must return *providers.DetectionError, got %T: %v", err, err)
+	}
+
+	switch detErr.Code {
+	case providers.ErrCodeClientOffline, providers.ErrCodeNotSignedIn:
+	default:
+		t.Fatalf("unexpected DetectionError.Code %q", detErr.Code)
+	}
+}


### PR DESCRIPTION
## Summary

- **Rocket League** added under both Epic Games and Steam networks. New `providers/epic` and `providers/steam` cover process detection; account auto-detection is deferred until SSO / `loginusers.vdf` integration.
- **Wizard restructured** to game-first: identity → game → network (single-select, only when the chosen game ships on 2+ stores) → details. Custom escape hatch lives on the game step.
- **`GameNetwork.SharedAccount` flag** (Riot=true) auto-tags an account with sibling games when one login spans them — picking LoL implicitly covers TFT + Valorant. Surfaced as a read-only "Linked games" note in the details step.
- **Sticky wizard** for first-account onboarding (when `accounts.length === 0`): backdrop and Esc dismissal disabled so a misclick can't tear users out of an empty-vault flow. Cancel still works.
- **AccountList game badge** resolves names from the catalog rather than the old hard-coded ternary that mis-labelled unknown game ids as "Valorant".
- Removed redundant header **Detect** button — manual rank detection still lives at Settings → Ranked → "Detect Ranks Now".

## Test plan

- [x] Go: `go test ./...` (all packages green; new `internal/models`, `providers/epic`, `providers/steam` covered)
- [x] Frontend: 80 vitest tests pass (4 new sticky-mode tests, new `lib/catalog.test.ts`, rewritten wizard tests for game-first flow + auto-link assertion)
- [x] Manual: vault unlock + existing accounts intact after rebase
- [x] Manual: fresh-vault → first-account flow shows sticky modal (backdrop/Esc no-op, Cancel exits)
- [x] Manual: pick Rocket League → network step is single-select Epic OR Steam (no "Add 2 Accounts")
- [x] Manual: pick LoL → "Linked games" note covers LoL + TFT + Valorant; account created with `games=['lol','tft','valorant']`
- [x] Manual: existing Rocket League card no longer says "Valorant"