### PR TITLE
Rebrand to Deckstr (with seamless update migration)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           $content = Get-Content installer/setup.iss -Raw
           $content = $content -replace '#define MyAppVersion "1.0.0"', '#define MyAppVersion "${{ steps.version.outputs.VERSION }}"'
-          $content = $content -replace 'OutputBaseFilename=OpenSmurfManager-Setup-1.0.0', 'OutputBaseFilename=OpenSmurfManager-Setup-${{ steps.version.outputs.VERSION }}'
+          $content = $content -replace 'OutputBaseFilename=Deckstr-Setup-1.0.0', 'OutputBaseFilename=Deckstr-Setup-${{ steps.version.outputs.VERSION }}'
           Set-Content installer/setup.iss $content
 
       - name: Build installer
@@ -58,7 +58,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: OpenSmurfManager-Windows
+          name: Deckstr-Windows
           path: build/installer/*.exe
 
   test:
@@ -93,7 +93,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          name: OpenSmurfManager v${{ steps.version.outputs.VERSION }}
+          name: Deckstr v${{ steps.version.outputs.VERSION }}
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OpenSmurfManager
+# Deckstr
 
 <div align="center">
 
@@ -19,11 +19,11 @@
 
 ---
 
-## Why OpenSmurfManager?
+## Why Deckstr?
 
 Managing multiple gaming accounts is a pain. Spreadsheets leak, browser passwords sync to clouds you don't control, and sticky notes... well, you know.
 
-**OpenSmurfManager** keeps your credentials **encrypted locally** on your machine. No cloud. No sync. No data leaving your computer. Just military-grade encryption protecting your accounts.
+**Deckstr** keeps your credentials **encrypted locally** on your machine. No cloud. No sync. No data leaving your computer. Just military-grade encryption protecting your accounts.
 
 ### Built by a Competitive Player
 
@@ -83,7 +83,7 @@ This isn't about stomping lower-ranked lobbies—it's about being able to queue 
 ### Quick Start (Windows)
 
 1. Download the latest installer from [Releases](https://github.com/ajanitshimanga/OpenSmurfManager/releases)
-2. Run `OpenSmurfManager-Setup-x.x.x.exe`
+2. Run `Deckstr-Setup-x.x.x.exe`
 3. Create your account with a strong master password
 4. Start adding your gaming accounts!
 
@@ -222,7 +222,7 @@ go test ./internal/crypto -v
 ### Project Structure
 
 ```
-OpenSmurfManager/
+Deckstr/
 ├── frontend/           # React + TypeScript UI
 │   ├── src/
 │   │   ├── components/ # UI components
@@ -284,20 +284,20 @@ Account storage works with any game. Automatic rank tracking for Valorant is on 
 <details>
 <summary><strong>Is this against Riot's Terms of Service?</strong></summary>
 
-OpenSmurfManager is a local password manager. It does not automate gameplay, inject into the client, or provide any competitive advantage. It simply stores your credentials securely, like any password manager.
+Deckstr is a local password manager. It does not automate gameplay, inject into the client, or provide any competitive advantage. It simply stores your credentials securely, like any password manager.
 </details>
 
 <details>
 <summary><strong>Can I sync across computers?</strong></summary>
 
-Not yet. The vault file is at `%APPDATA%\OpenSmurfManager\vault.osm` — you could manually copy it, but we recommend against it for security reasons. Encrypted cloud sync is on the future roadmap.
+Not yet. The vault file is at `%APPDATA%\Deckstr\vault.osm` (legacy installs were at `%APPDATA%\OpenSmurfManager\` — auto-migrated on first launch after rebrand) — you could manually copy it, but we recommend against it for security reasons. Encrypted cloud sync is on the future roadmap.
 </details>
 
 ---
 
 ## Support the Project
 
-If OpenSmurfManager saves you time, consider supporting development:
+If Deckstr saves you time, consider supporting development:
 
 <p align="center">
   <a href="https://github.com/sponsors/ajanitshimanga">

--- a/build-installer.bat
+++ b/build-installer.bat
@@ -2,7 +2,7 @@
 setlocal
 
 echo ========================================
-echo  OpenSmurfManager Production Build
+echo  Deckstr Production Build
 echo ========================================
 echo.
 
@@ -62,6 +62,6 @@ echo ========================================
 echo  Build Complete!
 echo ========================================
 echo.
-echo Installer: build\installer\OpenSmurfManager-Setup-1.0.0.exe
+echo Installer: build\installer\Deckstr-Setup-1.0.0.exe
 echo.
 pause

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-    <title>OpenSmurfManager</title>
+    <title>Deckstr</title>
 </head>
 <body>
 <div id="root"></div>

--- a/frontend/src/components/AccountList.tsx
+++ b/frontend/src/components/AccountList.tsx
@@ -257,7 +257,7 @@ export function AccountList() {
           </div>
           <div className="min-w-0">
             <h1 className="text-sm sm:text-base font-semibold text-[var(--color-foreground)] truncate">
-              SmurfManager
+              Deckstr
             </h1>
             <p className="text-[10px] sm:text-xs text-[var(--color-muted-foreground)] truncate">
               {username}

--- a/frontend/src/components/UnlockScreen.tsx
+++ b/frontend/src/components/UnlockScreen.tsx
@@ -338,7 +338,7 @@ export function UnlockScreen() {
             <KeyRound className="w-8 h-8 text-white" />
           </div>
           <h1 className="text-2xl font-bold text-[var(--color-foreground)]">
-            OpenSmurfManager
+            Deckstr
           </h1>
           <p className="text-[var(--color-primary)] text-sm font-medium mt-1">
             Centralize Your Accounts

--- a/frontend/src/components/WindowFrame.tsx
+++ b/frontend/src/components/WindowFrame.tsx
@@ -33,7 +33,7 @@ export function WindowFrame() {
       <div className="flex items-center gap-2" style={{ ['--wails-draggable' as any]: 'no-drag' }}>
         <Gamepad2 className="w-3.5 h-3.5 text-[var(--color-primary)]" />
         <span className="text-xs font-semibold text-[var(--color-foreground)] tracking-tight">
-          SmurfManager
+          Deckstr
         </span>
       </div>
 

--- a/installer/setup.iss
+++ b/installer/setup.iss
@@ -1,11 +1,11 @@
-; OpenSmurfManager Inno Setup Script
+; Deckstr Inno Setup Script
 ; Production-ready installer
 
-#define MyAppName "OpenSmurfManager"
+#define MyAppName "Deckstr"
 #define MyAppVersion "1.0.0"
-#define MyAppPublisher "OpenSmurfManager"
+#define MyAppPublisher "Deckstr"
 #define MyAppURL "https://github.com/ajanitshimanga/OpenSmurfManager"
-#define MyAppExeName "OpenSmurfManager.exe"
+#define MyAppExeName "Deckstr.exe"
 
 [Setup]
 ; Basic app info
@@ -24,7 +24,7 @@ DisableProgramGroupPage=yes
 
 ; Output settings
 OutputDir=..\build\installer
-OutputBaseFilename=OpenSmurfManager-Setup-{#MyAppVersion}
+OutputBaseFilename=Deckstr-Setup-{#MyAppVersion}
 SetupIconFile=..\build\windows\icon.ico
 UninstallDisplayIcon={app}\{#MyAppExeName}
 
@@ -112,6 +112,77 @@ begin
   end;
 end;
 
+// Migrate legacy %APPDATA%\OpenSmurfManager → %APPDATA%\Deckstr after install
+// but before the app is launched. Runs in three modes (mirrors the runtime
+// resolver in internal/appdir):
+//   1. Pure legacy: atomic rename. Fastest, journaled, survives crash.
+//   2. Split state (both exist): per-entry move where current doesn't already
+//      hold the file. Never overwrites — current always wins.
+//   3. Fresh install: nothing to do.
+// The runtime appdir.Path() is the safety net for any case the installer
+// missed (sideloaded binaries, weird AppData states).
+procedure MigrateLegacyAppData;
+var
+  LegacyDir, NewDir, SrcPath, DstPath: String;
+  FindRec: TFindRec;
+  Remaining: TFindRec;
+begin
+  LegacyDir := ExpandConstant('{userappdata}\OpenSmurfManager');
+  NewDir := ExpandConstant('{userappdata}\Deckstr');
+
+  if not DirExists(LegacyDir) then
+    Exit;
+
+  if not DirExists(NewDir) then
+  begin
+    // Mode 1: atomic rename. RenameFile handles dirs on Windows.
+    if RenameFile(LegacyDir, NewDir) then
+      Exit;
+    // Rename failed — ensure NewDir exists, then fall into per-entry merge.
+    if not ForceDirectories(NewDir) then
+      Exit;
+  end;
+
+  // Mode 2: per-entry merge. Don't overwrite anything that already exists
+  // in NewDir — silent overwrite of vault.osm would be the worst possible
+  // failure mode.
+  if FindFirst(LegacyDir + '\*', FindRec) then
+  try
+    repeat
+      if (FindRec.Name = '.') or (FindRec.Name = '..') then
+        Continue;
+      SrcPath := LegacyDir + '\' + FindRec.Name;
+      DstPath := NewDir + '\' + FindRec.Name;
+      if FileExists(DstPath) or DirExists(DstPath) then
+        Continue; // current wins, leave legacy copy in place
+      RenameFile(SrcPath, DstPath); // ignore errors per-entry
+    until not FindNext(FindRec);
+  finally
+    FindClose(FindRec);
+  end;
+
+  // Drop LegacyDir if the merge fully drained it.
+  if FindFirst(LegacyDir + '\*', Remaining) then
+  begin
+    try
+      // Skip the . and .. entries to determine emptiness.
+      repeat
+        if (Remaining.Name <> '.') and (Remaining.Name <> '..') then
+          Exit; // not empty, leave alone
+      until not FindNext(Remaining);
+    finally
+      FindClose(Remaining);
+    end;
+    RemoveDir(LegacyDir);
+  end;
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+  if CurStep = ssPostInstall then
+    MigrateLegacyAppData;
+end;
+
 // Offer to delete user data on uninstall
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 var
@@ -119,7 +190,7 @@ var
 begin
   if CurUninstallStep = usPostUninstall then
   begin
-    UserDataDir := ExpandConstant('{userappdata}\OpenSmurfManager');
+    UserDataDir := ExpandConstant('{userappdata}\Deckstr');
     if DirExists(UserDataDir) then
     begin
       if MsgBox('Do you want to delete your saved accounts and settings?' + #13#10 + #13#10 +

--- a/internal/appdir/appdir.go
+++ b/internal/appdir/appdir.go
@@ -1,0 +1,144 @@
+// Package appdir resolves the user-config directory the app stores its data
+// under and handles the one-shot migration from the legacy "OpenSmurfManager"
+// folder to the current "Deckstr" name.
+//
+// Both storage and telemetry call Path() — the migration runs at most once
+// per process and is idempotent across calls, so call ordering between
+// packages doesn't matter.
+package appdir
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	// CurrentName is the on-disk directory the app writes to today.
+	CurrentName = "Deckstr"
+	// LegacyName is the pre-rebrand directory we migrate from on first boot.
+	// Kept exported so tests + tooling can reason about the migration window.
+	LegacyName = "OpenSmurfManager"
+)
+
+var (
+	once   sync.Once
+	cached string
+	cerr   error
+)
+
+// Path returns the absolute path to the app's per-user data directory,
+// creating it (and migrating from the legacy name when applicable) on the
+// first call. Subsequent calls return the cached value.
+func Path() (string, error) {
+	once.Do(func() {
+		config, err := os.UserConfigDir()
+		if err != nil {
+			cerr = fmt.Errorf("appdir: user config dir: %w", err)
+			return
+		}
+		cached, cerr = resolveIn(config)
+	})
+	return cached, cerr
+}
+
+// resolveIn picks the active directory under the given config root, handling
+// the legacy → current migration in three modes:
+//
+//  1. Fresh install: create current, return.
+//  2. Pure legacy (legacy exists, current doesn't): atomic os.Rename — fastest
+//     and survives a crash mid-migration since rename is journaled.
+//  3. Split state (both dirs exist): walk legacy and move every entry that
+//     isn't already in current. Files in current always win — we never
+//     overwrite, so a corrupted half-migration that left an empty current
+//     dir doesn't destroy the legacy data. Once the merge is done, remove
+//     legacy if it's empty.
+//
+// Exported via the unexported name for tests that drive resolution against
+// a controlled tmpdir without touching real os.UserConfigDir state.
+func resolveIn(config string) (string, error) {
+	current := filepath.Join(config, CurrentName)
+	legacy := filepath.Join(config, LegacyName)
+
+	currentExists, err := dirExists(current)
+	if err != nil {
+		return "", err
+	}
+	legacyExists, err := dirExists(legacy)
+	if err != nil {
+		return "", err
+	}
+
+	switch {
+	case !currentExists && legacyExists:
+		// Mode 2: atomic rename. If it fails (permission, file handle), fall
+		// through to merge mode below by ensuring current exists.
+		if err := os.Rename(legacy, current); err == nil {
+			return current, nil
+		}
+		// Rename failed — create current and fall into merge.
+		if err := os.MkdirAll(current, 0700); err != nil {
+			return "", fmt.Errorf("appdir: mkdir after rename failed: %w", err)
+		}
+		fallthrough
+	case currentExists && legacyExists:
+		// Mode 3: per-entry merge. Don't overwrite anything in current — if
+		// both dirs hold a vault.osm, current wins (likely freshly created;
+		// the legacy one stays in place for manual recovery rather than
+		// being silently clobbered).
+		if err := mergeLegacyIntoCurrent(legacy, current); err != nil {
+			return "", err
+		}
+		return current, nil
+	default:
+		// Mode 1: fresh install (or current already present, no legacy).
+		if err := os.MkdirAll(current, 0700); err != nil {
+			return "", fmt.Errorf("appdir: mkdir: %w", err)
+		}
+		return current, nil
+	}
+}
+
+// mergeLegacyIntoCurrent moves every entry from legacy into current that
+// doesn't already exist in current. Conservative by design: never overwrites,
+// never deletes data it can't move. Removes legacy only if empty afterwards.
+func mergeLegacyIntoCurrent(legacy, current string) error {
+	entries, err := os.ReadDir(legacy)
+	if err != nil {
+		return fmt.Errorf("appdir: read legacy: %w", err)
+	}
+	for _, entry := range entries {
+		src := filepath.Join(legacy, entry.Name())
+		dst := filepath.Join(current, entry.Name())
+		if _, err := os.Stat(dst); err == nil {
+			// Already exists in current — skip to avoid overwriting.
+			continue
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("appdir: stat %s: %w", dst, err)
+		}
+		if err := os.Rename(src, dst); err != nil {
+			// Single-entry rename failure is non-fatal: leave it in legacy
+			// for manual recovery rather than aborting the whole merge.
+			continue
+		}
+	}
+	// Remove legacy only if completely empty post-merge.
+	remaining, err := os.ReadDir(legacy)
+	if err == nil && len(remaining) == 0 {
+		_ = os.Remove(legacy)
+	}
+	return nil
+}
+
+func dirExists(path string) (bool, error) {
+	info, err := os.Stat(path)
+	if err == nil {
+		return info.IsDir(), nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("appdir: stat %s: %w", path, err)
+}
+

--- a/internal/appdir/appdir_test.go
+++ b/internal/appdir/appdir_test.go
@@ -1,0 +1,194 @@
+package appdir
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveIn_FreshInstall pins that a brand-new install (no legacy dir,
+// no current dir) creates the current dir and returns its path.
+func TestResolveIn_FreshInstall(t *testing.T) {
+	root := t.TempDir()
+
+	got, err := resolveIn(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, CurrentName)
+	if got != want {
+		t.Errorf("resolveIn = %q, want %q", got, want)
+	}
+	if !dirExistsT(t, want) {
+		t.Errorf("expected %q to exist on disk after resolveIn", want)
+	}
+}
+
+// TestResolveIn_MigratesFromLegacy pins the rebrand-day behaviour: an
+// existing OpenSmurfManager dir with a vault inside is renamed to Deckstr,
+// preserving its contents.
+func TestResolveIn_MigratesFromLegacy(t *testing.T) {
+	root := t.TempDir()
+	legacy := filepath.Join(root, LegacyName)
+	if err := os.MkdirAll(legacy, 0700); err != nil {
+		t.Fatalf("seed legacy dir: %v", err)
+	}
+	// Drop a sentinel file so we can verify it survives the rename.
+	sentinelPath := filepath.Join(legacy, "vault.osm")
+	sentinelData := []byte("legacy-vault-bytes")
+	if err := os.WriteFile(sentinelPath, sentinelData, 0600); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+
+	got, err := resolveIn(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := filepath.Join(root, CurrentName)
+	if got != want {
+		t.Errorf("resolveIn = %q, want %q", got, want)
+	}
+	// The legacy dir must be gone — single rename, not a copy.
+	if dirExistsT(t, legacy) {
+		t.Errorf("legacy dir %q should not exist after migration", legacy)
+	}
+	// Sentinel must be readable at the new location with original bytes.
+	migratedSentinel := filepath.Join(want, "vault.osm")
+	gotBytes, err := os.ReadFile(migratedSentinel)
+	if err != nil {
+		t.Fatalf("read migrated sentinel: %v", err)
+	}
+	if string(gotBytes) != string(sentinelData) {
+		t.Errorf("migrated sentinel bytes = %q, want %q", gotBytes, sentinelData)
+	}
+}
+
+// TestResolveIn_PrefersCurrentWhenBothExist pins that if a user happens to
+// have both directories on disk (manual recovery, partial migration that
+// resumed), the current dir wins and the legacy one is left untouched for
+// the user to inspect/delete manually.
+func TestResolveIn_PrefersCurrentWhenBothExist(t *testing.T) {
+	root := t.TempDir()
+	legacy := filepath.Join(root, LegacyName)
+	current := filepath.Join(root, CurrentName)
+	if err := os.MkdirAll(legacy, 0700); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+	if err := os.MkdirAll(current, 0700); err != nil {
+		t.Fatalf("seed current: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "vault.osm"), []byte("legacy"), 0600); err != nil {
+		t.Fatalf("seed legacy file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(current, "vault.osm"), []byte("current"), 0600); err != nil {
+		t.Fatalf("seed current file: %v", err)
+	}
+
+	got, err := resolveIn(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != current {
+		t.Errorf("resolveIn = %q, want %q (current must win)", got, current)
+	}
+	if !dirExistsT(t, legacy) {
+		t.Errorf("legacy dir should remain when current already exists")
+	}
+}
+
+// TestResolveIn_MergesSplitState pins the recovery path for partially-failed
+// migrations: legacy still has a vault.osm but current already exists with
+// some files (say, freshly-created logs). The merge moves the legacy vault
+// into current without overwriting anything, then drops the legacy dir.
+func TestResolveIn_MergesSplitState(t *testing.T) {
+	root := t.TempDir()
+	legacy := filepath.Join(root, LegacyName)
+	current := filepath.Join(root, CurrentName)
+	if err := os.MkdirAll(legacy, 0700); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+	if err := os.MkdirAll(current, 0700); err != nil {
+		t.Fatalf("seed current: %v", err)
+	}
+	// Legacy has the user's real vault. Current has fresh telemetry artifacts
+	// (mimicking the broken state where another process created current first).
+	realVault := []byte("real-vault-data")
+	if err := os.WriteFile(filepath.Join(legacy, "vault.osm"), realVault, 0600); err != nil {
+		t.Fatalf("seed legacy vault: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(current, "client.id"), []byte("abc-123"), 0600); err != nil {
+		t.Fatalf("seed current client.id: %v", err)
+	}
+
+	got, err := resolveIn(root)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != current {
+		t.Errorf("resolveIn = %q, want %q", got, current)
+	}
+	// Legacy vault must have moved into current.
+	migrated, err := os.ReadFile(filepath.Join(current, "vault.osm"))
+	if err != nil {
+		t.Fatalf("read migrated vault: %v", err)
+	}
+	if string(migrated) != string(realVault) {
+		t.Errorf("migrated vault bytes = %q, want %q", migrated, realVault)
+	}
+	// Legacy dir should be gone since merge cleared it.
+	if dirExistsT(t, legacy) {
+		t.Errorf("legacy dir should be removed after a clean merge")
+	}
+}
+
+// TestResolveIn_MergeNeverOverwrites pins the safety property: if both dirs
+// hold a vault.osm, the current one wins and the legacy file stays in place
+// for manual recovery. Silent overwrite of vault data is the worst possible
+// failure mode for a password manager.
+func TestResolveIn_MergeNeverOverwrites(t *testing.T) {
+	root := t.TempDir()
+	legacy := filepath.Join(root, LegacyName)
+	current := filepath.Join(root, CurrentName)
+	if err := os.MkdirAll(legacy, 0700); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+	if err := os.MkdirAll(current, 0700); err != nil {
+		t.Fatalf("seed current: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(legacy, "vault.osm"), []byte("legacy-real"), 0600); err != nil {
+		t.Fatalf("seed legacy vault: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(current, "vault.osm"), []byte("current-stub"), 0600); err != nil {
+		t.Fatalf("seed current vault: %v", err)
+	}
+
+	if _, err := resolveIn(root); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	currentBytes, _ := os.ReadFile(filepath.Join(current, "vault.osm"))
+	if string(currentBytes) != "current-stub" {
+		t.Errorf("current vault was overwritten: got %q, want %q", currentBytes, "current-stub")
+	}
+	legacyBytes, err := os.ReadFile(filepath.Join(legacy, "vault.osm"))
+	if err != nil {
+		t.Fatalf("legacy vault was destroyed: %v", err)
+	}
+	if string(legacyBytes) != "legacy-real" {
+		t.Errorf("legacy vault was modified: got %q, want %q", legacyBytes, "legacy-real")
+	}
+}
+
+func dirExistsT(t *testing.T, path string) bool {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+		t.Fatalf("stat %q: %v", path, err)
+	}
+	return info.IsDir()
+}

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -9,14 +9,18 @@ import (
 	"sync"
 	"time"
 
+	"OpenSmurfManager/internal/appdir"
 	"OpenSmurfManager/internal/crypto"
 	"OpenSmurfManager/internal/models"
 )
 
 const (
-	vaultFileName    = "vault.osm" // OpenSmurfManager vault file
-	vaultVersion     = 1           // Increment when making breaking changes to vault structure
-	configDirName    = "OpenSmurfManager"
+	// vaultFileName is intentionally unchanged across the Deckstr rebrand —
+	// the .osm extension lives inside the per-user data directory and isn't
+	// user-facing, so renaming it would force a second migration with no UX
+	// benefit.
+	vaultFileName = "vault.osm"
+	vaultVersion  = 1 // Increment when making breaking changes to vault structure
 )
 
 // Migration notes:
@@ -72,19 +76,15 @@ func NewStorageServiceWithPath(vaultPath string) *StorageService {
 	}
 }
 
-// getVaultPath returns the path to the vault file
+// getVaultPath returns the path to the vault file. The directory resolution
+// (and any rebrand migration) is delegated to internal/appdir so storage and
+// telemetry agree on a single canonical location.
 func getVaultPath() (string, error) {
-	configDir, err := os.UserConfigDir()
+	dir, err := appdir.Path()
 	if err != nil {
-		return "", fmt.Errorf("failed to get config directory: %w", err)
+		return "", fmt.Errorf("failed to resolve app directory: %w", err)
 	}
-
-	appDir := filepath.Join(configDir, configDirName)
-	if err := os.MkdirAll(appDir, 0700); err != nil {
-		return "", fmt.Errorf("failed to create app directory: %w", err)
-	}
-
-	return filepath.Join(appDir, vaultFileName), nil
+	return filepath.Join(dir, vaultFileName), nil
 }
 
 // VaultExists checks if a vault file exists

--- a/internal/telemetry/paths.go
+++ b/internal/telemetry/paths.go
@@ -4,26 +4,28 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"OpenSmurfManager/internal/appdir"
 )
 
 const (
-	appDirName      = "OpenSmurfManager"
-	logsDirName     = "logs"
-	logFileName     = "app.log"
-	clientIDFile    = "client.id"
-	defaultMaxSize  = 1 * 1024 * 1024 // 1 MB per file
-	defaultBackups  = 3               // keep .1, .2, .3 → 4 files total (~4 MB cap)
-	defaultFlushEvery = 5             // seconds
+	logsDirName       = "logs"
+	logFileName       = "app.log"
+	clientIDFile      = "client.id"
+	defaultMaxSize    = 1 * 1024 * 1024 // 1 MB per file
+	defaultBackups    = 3               // keep .1, .2, .3 → 4 files total (~4 MB cap)
+	defaultFlushEvery = 5               // seconds
 )
 
-// logsDir returns the directory where rotated log files live.
-// Matches the vault location convention (os.UserConfigDir/OpenSmurfManager).
+// logsDir returns the directory where rotated log files live, sitting under
+// the shared per-user app dir (handled by internal/appdir, including the
+// rebrand migration from the legacy folder name).
 func logsDir() (string, error) {
-	config, err := os.UserConfigDir()
+	app, err := appdir.Path()
 	if err != nil {
-		return "", fmt.Errorf("telemetry: user config dir: %w", err)
+		return "", fmt.Errorf("telemetry: app dir: %w", err)
 	}
-	dir := filepath.Join(config, appDirName, logsDirName)
+	dir := filepath.Join(app, logsDirName)
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", fmt.Errorf("telemetry: mkdir logs: %w", err)
 	}
@@ -34,13 +36,9 @@ func logsDir() (string, error) {
 // Stored next to the vault, outside the encrypted blob so it's available
 // before unlock (needed to emit pre-unlock events like app.start).
 func clientIDPath() (string, error) {
-	config, err := os.UserConfigDir()
+	app, err := appdir.Path()
 	if err != nil {
-		return "", fmt.Errorf("telemetry: user config dir: %w", err)
+		return "", fmt.Errorf("telemetry: app dir: %w", err)
 	}
-	dir := filepath.Join(config, appDirName)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return "", fmt.Errorf("telemetry: mkdir app: %w", err)
-	}
-	return filepath.Join(dir, clientIDFile), nil
+	return filepath.Join(app, clientIDFile), nil
 }

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func main() {
 
 	// Telemetry is best-effort — if it can't initialise (unwritable config
 	// dir, etc.) we log to stderr and keep running.
-	if err := telemetry.Init("OpenSmurfManager", updater.Version); err != nil {
+	if err := telemetry.Init("Deckstr", updater.Version); err != nil {
 		println("telemetry init failed:", err.Error())
 	}
 	defer telemetry.Close()
@@ -36,7 +36,7 @@ func main() {
 	// Create application with options
 	// Start with login size (vertical), will resize after unlock
 	err := wails.Run(&options.App{
-		Title:     "SmurfManager",
+		Title:     "Deckstr",
 		// One size across login + main so unlocking doesn't resize the window.
 		Width:     520,
 		Height:    760,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opensmurfmanager",
+  "name": "deckstr",
   "version": "1.1.0",
   "description": "Secure local account manager for gamers",
   "scripts": {

--- a/wails.json
+++ b/wails.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://wails.io/schemas/config.v2.json",
-  "name": "OpenSmurfManager",
-  "outputfilename": "OpenSmurfManager",
+  "name": "Deckstr",
+  "outputfilename": "Deckstr",
   "frontend:install": "npm install",
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",


### PR DESCRIPTION
## Summary

Renames the user-facing product from **OpenSmurfManager** / **SmurfManager** to **Deckstr** (short for "Deck Storage"). Single-cap brand, drops the smurfing baggage, fits better as the product grows beyond Riot/competitive titles.

## Two-layer AppData migration

Updaters from v1.2.x must land on the new vault location without losing data. Done in **two layers** so it works even if one fails:

1. **Installer-time** (`installer/setup.iss`): `MigrateLegacyAppData` Pascal procedure runs at `ssPostInstall`, *before* the new exe launches. Tries atomic dir rename first; falls back to per-entry merge if both dirs already exist.
2. **Runtime fallback** (`internal/appdir`): new shared package called by both storage and telemetry. Mirrors the same three-mode resolver — fresh install, atomic rename, split-state merge. Covers sideloaded binaries and any state the installer missed.

**Never-overwrite invariant:** if `vault.osm` exists in both locations, the new location wins and the legacy file stays put for manual recovery. Silent overwrite of vault data would be the worst possible failure mode.

## Changes

- Window title, window-frame brand, account-list header, unlock-screen header, HTML title, telemetry `service.name`, root `package.json` name → **Deckstr**
- `wails.json` output → `Deckstr.exe`
- Inno Setup → `Deckstr-Setup-x.x.x.exe`
- GitHub release name + artifact reflect Deckstr
- README copy updated
- Vault file extension stays `vault.osm` (internal-only, avoids second migration)
- Go module path stays `OpenSmurfManager/...` (internal-only, would touch every import for zero user benefit)
- GitHub repo rename **not** included — URLs in README still point at the existing repo until that's done as a follow-up

## Test plan

- [x] Go: full suite (`go test ./...`) — 5 new appdir migration tests covering fresh install, atomic rename, already-migrated, split-state merge, never-overwrite safety
- [x] Frontend: 85 vitest tests pass
- [x] Manual: clean build (`Deckstr.exe` produced)
- [x] Manual: real-world migration verified — my own `%APPDATA%/OpenSmurfManager/vault.osm` (4978 bytes) was successfully merged into `%APPDATA%/Deckstr/` on launch via the runtime resolver, with no data loss
- [x] Manual: app launches, unlocks with existing credentials, all accounts present
- [ ] Future manual: full installer round-trip on a clean Win VM (would catch any Inno Setup syntax issues that the Go tests can't reach)